### PR TITLE
tests: use testify for more concise assertions

### DIFF
--- a/cram_test.go
+++ b/cram_test.go
@@ -3,64 +3,42 @@ package cram
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseEmpty(t *testing.T) {
 	buf := strings.NewReader("")
 	cmds, err := ParseTest(buf)
 
-	if err != nil {
-		t.Error("Expected no error, got", err)
-	}
-
-	if len(cmds) > 0 {
-		t.Error("Expected no commands, got", cmds)
-	}
+	assert.NoError(t, err)
+	assert.Len(t, cmds, 0)
 }
 
 func TestParseCommentaryOnly(t *testing.T) {
 	buf := strings.NewReader("This file only has\nsome commentary.\n")
 	cmds, err := ParseTest(buf)
 
-	if err != nil {
-		t.Error("Expected no error, got", err)
-	}
-
-	if len(cmds) > 0 {
-		t.Error("Expected no commands, got", cmds)
-	}
+	assert.NoError(t, err)
+	assert.Len(t, cmds, 0)
 }
 
 func TestParseNoOutput(t *testing.T) {
+	assert := assert.New(t)
 	buf := strings.NewReader(`
   $ touch foo
   $ touch bar
 `)
 	cmds, err := ParseTest(buf)
-
-	if err != nil {
-		t.Error("Expected no error, got", err)
-	}
-
-	if len(cmds) == 2 {
-		if cmds[0].CmdLine != "touch foo" {
-			t.Error("Expected touch foo, got", cmds[0])
-		}
-		if len(cmds[0].ExpectedOutput) > 0 {
-			t.Error("Expected no output, got", cmds[0].ExpectedOutput)
-		}
-		if cmds[1].CmdLine != "touch bar" {
-			t.Error("Expected touch bar, got", cmds[1])
-		}
-		if len(cmds[1].ExpectedOutput) > 0 {
-			t.Error("Expected no output, got", cmds[1].ExpectedOutput)
-		}
-	} else {
-		t.Error("Expected two commands, got", cmds)
+	assert.NoError(err)
+	if assert.Len(cmds, 2) {
+		assert.Equal(Command{"touch foo", nil}, cmds[0])
+		assert.Equal(Command{"touch bar", nil}, cmds[1])
 	}
 }
 
 func TestParseCommands(t *testing.T) {
+	assert := assert.New(t)
 	buf := strings.NewReader(`
   $ echo "hello\nworld"
   hello
@@ -69,36 +47,16 @@ func TestParseCommands(t *testing.T) {
   goodbye
 `)
 	cmds, err := ParseTest(buf)
+	assert.NoError(err)
 
-	if err != nil {
-		t.Error("Expected no error, got", err)
-	}
-
-	if len(cmds) == 2 {
-		if cmds[0].CmdLine != `echo "hello\nworld"` {
-			t.Error("Expected echo hello\\nworld, got", cmds[0])
-		}
-		if len(cmds[0].ExpectedOutput) == 2 {
-			if cmds[0].ExpectedOutput[0] != "hello" {
-				t.Error("Expected hello, got", cmds[0].ExpectedOutput[0])
-			}
-			if cmds[0].ExpectedOutput[1] != "world" {
-				t.Error("Expected world, got", cmds[0].ExpectedOutput[1])
-			}
-		} else {
-			t.Error("Expected two output lines, got", cmds[0].ExpectedOutput)
-		}
-		if cmds[1].CmdLine != "echo goodbye" {
-			t.Error("Expected echo goodbye, got", cmds[1])
-		}
-		if len(cmds[1].ExpectedOutput) == 1 {
-			if cmds[1].ExpectedOutput[0] != "goodbye" {
-				t.Error("Expected goodbye, got", cmds[1].ExpectedOutput[1])
-			}
-		} else {
-			t.Error("Expected one output line, got", cmds[1].ExpectedOutput)
-		}
-	} else {
-		t.Error("Expected two commands, got", cmds)
+	if assert.Len(cmds, 2) {
+		assert.Equal(Command{
+			`echo "hello\nworld"`,
+			[]string{"hello", "world"},
+		}, cmds[0])
+		assert.Equal(Command{
+			"echo goodbye",
+			[]string{"goodbye"},
+		}, cmds[1])
 	}
 }

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,7 +8,6 @@ go:
 
 build:
   ci:
-    - mkdir -p shippable/testresults
     - go get github.com/jstemmer/go-junit-report
     - go get -d -v ./...
     - go build -v ./...


### PR DESCRIPTION
The assert.Equal function does deep comparisons with arbitrary types, and this removes a lot of boilerplate code from our tests.

Unlike Gocheck (see #5), the testify library keeps the test structure and test output mostly unchanged.
