### PR TITLE
Parse and handle exit codes

### DIFF
--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -63,6 +63,15 @@ func run(ctx *cli.Context) {
 
 	fmt.Printf("# Ran %d tests (%d commands), %d errors, %d failures.\n",
 		len(ctx.Args()), cmdCount, errors, len(failures))
+
+	switch {
+	case errors > 0:
+		os.Exit(2)
+	case len(failures) > 0:
+		os.Exit(1)
+	default:
+		os.Exit(0)
+	}
 }
 
 func main() {

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -12,13 +12,18 @@ import (
 
 func showFailures(failures []cram.ExecutedCommand) {
 	for _, cmd := range failures {
-		actual := strings.Join(cmd.ActualOutput, "\n  ")
-		expected := strings.Join(cmd.ExpectedOutput, "\n  ")
-
 		fmt.Printf("When executing %+#v, got\n", cmd.CmdLine)
-		fmt.Println(" ", actual)
-		fmt.Println("but expected")
-		fmt.Println(" ", expected)
+		if cmd.ActualExitCode != cmd.ExpectedExitCode {
+			fmt.Printf("  exit code %d, but expected %d\n",
+				cmd.ActualExitCode, cmd.ExpectedExitCode)
+		} else {
+			actual := strings.Join(cmd.ActualOutput, "\n  ")
+			expected := strings.Join(cmd.ExpectedOutput, "\n  ")
+
+			fmt.Println(" ", actual)
+			fmt.Println("but expected")
+			fmt.Println(" ", expected)
+		}
 	}
 }
 

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,7 +12,7 @@ import (
 
 func showFailures(failures []cram.ExecutedCommand) {
 	for _, cmd := range failures {
-		actual := string(bytes.Join(cmd.ActualOutput, []byte("\n  ")))
+		actual := strings.Join(cmd.ActualOutput, "\n  ")
 		expected := strings.Join(cmd.ExpectedOutput, "\n  ")
 
 		fmt.Printf("When executing %+#v, got\n", cmd.CmdLine)

--- a/cram.go
+++ b/cram.go
@@ -20,8 +20,9 @@ const (
 )
 
 type Command struct {
-	CmdLine        string   // Command line as it will be passed to the shell.
-	ExpectedOutput []string // Expected output lines.
+	CmdLine          string   // Command line passed to the shell.
+	ExpectedOutput   []string // Expected output lines.
+	ExpectedExitCode int      // Expected exit code.
 }
 
 type ExecutedCommand struct {

--- a/cram.go
+++ b/cram.go
@@ -25,9 +25,9 @@ type Command struct {
 }
 
 type ExecutedCommand struct {
-	*Command              // Command responsible for the output.
-	ActualOutput []string // Actual output read from stdout and stderr.
-	ExitCode     int      // Exit code.
+	*Command                // Command responsible for the output.
+	ActualOutput   []string // Actual output read from stdout and stderr.
+	ActualExitCode int      // Exit code.
 }
 
 type Result struct {
@@ -89,9 +89,9 @@ func ParseOutput(cmds []Command, output []byte, banner string) (
 				return
 			}
 			executed = append(executed, ExecutedCommand{
-				Command:      &cmds[i],
-				ExitCode:     exitCode,
-				ActualOutput: actualOutput,
+				Command:        &cmds[i],
+				ActualExitCode: exitCode,
+				ActualOutput:   actualOutput,
 			})
 			actualOutput = nil
 			i++

--- a/cram.go
+++ b/cram.go
@@ -21,7 +21,7 @@ const (
 
 type Command struct {
 	CmdLine        string   // Command line as it will be passed to the shell.
-	ExpectedOutput []string // Expected output including any newlines.
+	ExpectedOutput []string // Expected output lines.
 }
 
 type ExecutedCommand struct {

--- a/cram.go
+++ b/cram.go
@@ -158,9 +158,15 @@ func ExecuteScript(workdir string, lines []string) ([]byte, error) {
 
 func filterFailures(executed []ExecutedCommand) (failures []ExecutedCommand) {
 	for _, cmd := range executed {
-		actual := strings.Join(cmd.ActualOutput, "\n")
-		expected := strings.Join(cmd.ExpectedOutput, "\n")
-		if actual != expected {
+		// Quick check first
+		err := cmd.ActualExitCode != cmd.ExpectedExitCode
+		// More expensive check next
+		if !err {
+			actual := strings.Join(cmd.ActualOutput, "\n")
+			expected := strings.Join(cmd.ExpectedOutput, "\n")
+			err = actual != expected
+		}
+		if err {
 			failures = append(failures, cmd)
 		}
 	}

--- a/cram_test.go
+++ b/cram_test.go
@@ -33,8 +33,8 @@ func TestParseNoOutput(t *testing.T) {
 	cmds, err := ParseTest(buf)
 	assert.NoError(err)
 	if assert.Len(cmds, 2) {
-		assert.Equal(Command{"touch foo", nil}, cmds[0])
-		assert.Equal(Command{"touch bar", nil}, cmds[1])
+		assert.Equal(Command{"touch foo", nil, 0}, cmds[0])
+		assert.Equal(Command{"touch bar", nil, 0}, cmds[1])
 	}
 }
 
@@ -54,10 +54,12 @@ func TestParseCommands(t *testing.T) {
 		assert.Equal(Command{
 			`echo "hello\nworld"`,
 			[]string{"hello", "world"},
+			0,
 		}, cmds[0])
 		assert.Equal(Command{
 			"echo goodbye",
 			[]string{"goodbye"},
+			0,
 		}, cmds[1])
 	}
 }
@@ -73,7 +75,7 @@ func TestMakeScriptEmpty(t *testing.T) {
 func TestMakeScript(t *testing.T) {
 	u, err := uuid.FromString("123456781234abcd1234123412345678")
 	assert.NoError(t, err)
-	cmds := []Command{{"ls", nil}, {"touch foo.txt", nil}}
+	cmds := []Command{{"ls", nil, 0}, {"touch foo.txt", nil, 0}}
 	lines := MakeScript(cmds, MakeBanner(u))
 	banner := `echo "--- CRAM 12345678-1234-abcd-1234-123412345678 --- $?"`
 	if assert.Len(t, lines, 4) {
@@ -86,8 +88,8 @@ func TestMakeScript(t *testing.T) {
 
 func TestParseOutputEmpty(t *testing.T) {
 	cmds := []Command{
-		{"touch foo", nil},
-		{"touch bar", nil},
+		{"touch foo", nil, 0},
+		{"touch bar", nil, 0},
 	}
 	banner := "--- CRAM 12345678-1234-abcd-1234-123412345678 ---"
 	output := []byte(`--- CRAM 12345678-1234-abcd-1234-123412345678 --- 0
@@ -106,8 +108,8 @@ func TestParseOutputEmpty(t *testing.T) {
 
 func TestParseOutput(t *testing.T) {
 	cmds := []Command{
-		{"echo foo", []string{"foo"}},
-		{"echo bar", []string{"bar"}},
+		{"echo foo", []string{"foo"}, 0},
+		{"echo bar", []string{"bar"}, 0},
 	}
 	banner := "--- CRAM 12345678-1234-abcd-1234-123412345678 ---"
 	output := []byte(`foo

--- a/cram_test.go
+++ b/cram_test.go
@@ -64,6 +64,41 @@ func TestParseCommands(t *testing.T) {
 	}
 }
 
+func TestParseExitCodes(t *testing.T) {
+	assert := assert.New(t)
+	buf := strings.NewReader(`
+Command with exit code but no output:
+
+  $ false
+  [1]
+
+Commandline with exit code and output:
+
+  $ echo hello; false
+  hello
+  [1]
+
+Mixture of commands and output:
+
+  $ false
+  [1]
+  $ true
+  $ echo hello; false
+  hello
+  [1]
+`)
+	cmds, err := ParseTest(buf)
+	assert.NoError(err)
+
+	if assert.Len(cmds, 5) {
+		assert.Equal(Command{"false", []string{}, 1}, cmds[0])
+		assert.Equal(Command{"echo hello; false", []string{"hello"}, 1}, cmds[1])
+		assert.Equal(Command{"false", []string{}, 1}, cmds[2])
+		assert.Equal(Command{"true", nil, 0}, cmds[3])
+		assert.Equal(Command{"echo hello; false", []string{"hello"}, 1}, cmds[4])
+	}
+}
+
 func TestMakeScriptEmpty(t *testing.T) {
 	u, err := uuid.FromString("123456781234abcd1234123412345678")
 	assert.NoError(t, err)

--- a/cram_test.go
+++ b/cram_test.go
@@ -119,9 +119,9 @@ bar
 	executed, err := ParseOutput(cmds, output, banner)
 	assert.NoError(t, err)
 	if assert.Len(t, executed, 2) {
-		assert.Equal(t, [][]byte{[]byte("foo")}, executed[0].ActualOutput)
+		assert.Equal(t, []string{"foo"}, executed[0].ActualOutput)
 		assert.Equal(t, 0, executed[0].ExitCode)
-		assert.Equal(t, [][]byte{[]byte("bar")}, executed[1].ActualOutput)
+		assert.Equal(t, []string{"bar"}, executed[1].ActualOutput)
 		assert.Equal(t, 1, executed[1].ExitCode)
 	}
 }

--- a/cram_test.go
+++ b/cram_test.go
@@ -98,9 +98,9 @@ func TestParseOutputEmpty(t *testing.T) {
 	assert.NoError(t, err)
 	if assert.Len(t, executed, 2) {
 		assert.Len(t, executed[0].ActualOutput, 0)
-		assert.Equal(t, 0, executed[0].ExitCode)
+		assert.Equal(t, 0, executed[0].ActualExitCode)
 		assert.Len(t, executed[1].ActualOutput, 0)
-		assert.Equal(t, 1, executed[1].ExitCode)
+		assert.Equal(t, 1, executed[1].ActualExitCode)
 	}
 }
 
@@ -120,8 +120,8 @@ bar
 	assert.NoError(t, err)
 	if assert.Len(t, executed, 2) {
 		assert.Equal(t, []string{"foo"}, executed[0].ActualOutput)
-		assert.Equal(t, 0, executed[0].ExitCode)
+		assert.Equal(t, 0, executed[0].ActualExitCode)
 		assert.Equal(t, []string{"bar"}, executed[1].ActualOutput)
-		assert.Equal(t, 1, executed[1].ExitCode)
+		assert.Equal(t, 1, executed[1].ActualExitCode)
 	}
 }

--- a/tests/exit-codes.t
+++ b/tests/exit-codes.t
@@ -1,27 +1,26 @@
 Cram will normally exit with a status of 0 to indicate success:
 
   $ touch empty.t
-  $ cram empty.t; echo "Cram exit code: $?"
+  $ cram empty.t
   .
   # Ran 1 tests (0 commands), 0 errors, 0 failures.
-  Cram exit code: 0
 
 Test failures set the exit code to 1:
 
   $ echo '  $ echo foo' >> extra-output.t
-  $ cram *.t; echo "Cram exit code: $?"
+  $ cram *.t
   .F
   When executing "echo foo", got
     foo
   but expected
     
   # Ran 2 tests (1 commands), 0 errors, 1 failures.
-  Cram exit code: 1
+  [1]
 
 If an error occurs, the error is shown, the error count incremented,
 and the exit code is set to 2:
 
-  $ cram does-not-exist.t *.t; echo "Cram exit code: $?"
+  $ cram does-not-exist.t *.t
   open does-not-exist.t: no such file or directory
   E.F
   When executing "echo foo", got
@@ -29,4 +28,24 @@ and the exit code is set to 2:
   but expected
     
   # Ran 3 tests (1 commands), 1 errors, 1 failures.
-  Cram exit code: 2
+  [2]
+
+A command with no output can also have a non-zero exit code:
+
+  $ false
+  [1]
+
+Though it is redundant, a zero exit code can still be specified:
+
+  $ true
+  [0]
+
+Mismatches in exit codes are shown in the Cram output:
+
+  $ echo '  $ false' >> false.t
+  $ cram false.t
+  F
+  When executing "false", got
+    exit code 1, but expected 0
+  # Ran 1 tests (1 commands), 0 errors, 1 failures.
+  [1]

--- a/tests/exit-codes.t
+++ b/tests/exit-codes.t
@@ -1,0 +1,32 @@
+Cram will normally exit with a status of 0 to indicate success:
+
+  $ touch empty.t
+  $ cram empty.t; echo "Cram exit code: $?"
+  .
+  # Ran 1 tests (0 commands), 0 errors, 0 failures.
+  Cram exit code: 0
+
+Test failures set the exit code to 1:
+
+  $ echo '  $ echo foo' >> extra-output.t
+  $ cram *.t; echo "Cram exit code: $?"
+  .F
+  When executing "echo foo", got
+    foo
+  but expected
+    
+  # Ran 2 tests (1 commands), 0 errors, 1 failures.
+  Cram exit code: 1
+
+If an error occurs, the error is shown, the error count incremented,
+and the exit code is set to 2:
+
+  $ cram does-not-exist.t *.t; echo "Cram exit code: $?"
+  open does-not-exist.t: no such file or directory
+  E.F
+  When executing "echo foo", got
+    foo
+  but expected
+    
+  # Ran 3 tests (1 commands), 1 errors, 1 failures.
+  Cram exit code: 2

--- a/tests/failures.t
+++ b/tests/failures.t
@@ -9,3 +9,4 @@ Cram shows the failed command with the actual and expected output:
   but expected
     bar
   # Ran 1 tests (1 commands), 0 errors, 1 failures.
+  [1]


### PR DESCRIPTION
This makes Cram parse expected exit codes in the test files. Cram itself will now also return a proper exit code:
- 0 for success,
- 1 if there are failures (a test command has unexpected output), and
- 2 if there are errors (a test file cannot be read).
