### PR TITLE
gitignore: add autogenerated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *#
 *~
+*.orig
+
+cram.test


### PR DESCRIPTION
Some merge tools (such as KDiff3) leave `.orig` files behind. The `cram.test` binary seems to be generated by `go test` and left behind if a test fails.
