### PR TITLE
readme: add shields.io badge for Shippable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cram: Command-Line Functional Test Framework
 
+[![Shippable](https://img.shields.io/shippable/5701519833e2f1203f8ca8d0.svg?maxAge=86400)](https://app.shippable.com/projects/5701519833e2f1203f8ca8d0)
+
 This is a Go port of the [Cram][] command-line test framework. Cram
 makes it easy to test command-line programs by recording commands with
 their expected output.


### PR DESCRIPTION
Shippable also has a badge, but it looks a little strange and uses the
text "run shippable" instead of "build passed", which I don't think is
very clear to anybody.

Luckily shields.io can generate a "standard" badge with a standard text.

See https://github.com/Shippable/support/issues/2461.
