### PR TITLE
Add --interactive flag

### DIFF
--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -69,7 +69,7 @@ func run(ctx *cli.Context) {
 			fmt.Fprintln(os.Stderr, result.Script)
 		}
 
-		cmdCount += len(result.Commands)
+		cmdCount += len(result.Cmds)
 
 		switch {
 		case err != nil:

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,6 +10,26 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/mgeisler/cram"
 )
+
+func booleanPrompt(prompt string) (bool, error) {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Print(prompt, " ")
+		answer, err := reader.ReadString('\n')
+		if err != nil {
+			return false, err
+		}
+		answer = strings.ToLower(strings.TrimSpace(answer))
+		switch answer {
+		case "y", "yes":
+			return true, nil
+		case "n", "no":
+			return false, nil
+		default:
+			fmt.Println("Please answer 'yes' or 'no'")
+		}
+	}
+}
 
 func showFailures(failures []cram.ExecutedCommand) {
 	for _, cmd := range failures {

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -31,19 +31,21 @@ func booleanPrompt(prompt string) (bool, error) {
 	}
 }
 
-func showFailures(failures []cram.ExecutedCommand) {
-	for _, cmd := range failures {
-		fmt.Printf("When executing %+#v, got\n", cram.DropEol(cmd.CmdLine))
-		if cmd.ActualExitCode != cmd.ExpectedExitCode {
-			fmt.Printf("  exit code %d, but expected %d\n",
-				cmd.ActualExitCode, cmd.ExpectedExitCode)
-		} else {
-			actual := cram.DropEol(strings.Join(cmd.ActualOutput, "  "))
-			expected := cram.DropEol(strings.Join(cmd.ExpectedOutput, "  "))
+func showFailures(tests []cram.ExecutedTest) {
+	for _, test := range tests {
+		for _, cmd := range test.Failures {
+			fmt.Printf("When executing %+#v, got\n", cram.DropEol(cmd.CmdLine))
+			if cmd.ActualExitCode != cmd.ExpectedExitCode {
+				fmt.Printf("  exit code %d, but expected %d\n",
+					cmd.ActualExitCode, cmd.ExpectedExitCode)
+			} else {
+				actual := cram.DropEol(strings.Join(cmd.ActualOutput, "  "))
+				expected := cram.DropEol(strings.Join(cmd.ExpectedOutput, "  "))
 
-			fmt.Println(" ", actual)
-			fmt.Println("but expected")
-			fmt.Println(" ", expected)
+				fmt.Println(" ", actual)
+				fmt.Println("but expected")
+				fmt.Println(" ", expected)
+			}
 		}
 	}
 }
@@ -60,7 +62,7 @@ func run(ctx *cli.Context) {
 	}
 
 	errors, cmdCount := 0, 0
-	failures := []cram.ExecutedCommand{}
+	failures := []cram.ExecutedTest{}
 
 	for _, path := range ctx.Args() {
 		result, err := cram.Process(tempdir, path)
@@ -78,7 +80,7 @@ func run(ctx *cli.Context) {
 			errors++
 		case len(result.Failures) > 0:
 			fmt.Print("F")
-			failures = append(failures, result.Failures...)
+			failures = append(failures, result)
 		default:
 			fmt.Print(".")
 		}

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -33,13 +33,13 @@ func booleanPrompt(prompt string) (bool, error) {
 
 func showFailures(failures []cram.ExecutedCommand) {
 	for _, cmd := range failures {
-		fmt.Printf("When executing %+#v, got\n", cmd.CmdLine)
+		fmt.Printf("When executing %+#v, got\n", cram.DropEol(cmd.CmdLine))
 		if cmd.ActualExitCode != cmd.ExpectedExitCode {
 			fmt.Printf("  exit code %d, but expected %d\n",
 				cmd.ActualExitCode, cmd.ExpectedExitCode)
 		} else {
-			actual := strings.Join(cmd.ActualOutput, "\n  ")
-			expected := strings.Join(cmd.ExpectedOutput, "\n  ")
+			actual := cram.DropEol(strings.Join(cmd.ActualOutput, "  "))
+			expected := cram.DropEol(strings.Join(cmd.ExpectedOutput, "  "))
 
 			fmt.Println(" ", actual)
 			fmt.Println("but expected")

--- a/cram.go
+++ b/cram.go
@@ -28,7 +28,6 @@ type Command struct {
 	CmdLine          string   // Command line passed to the shell.
 	ExpectedOutput   []string // Expected output lines.
 	ExpectedExitCode int      // Expected exit code.
-	Path             string   // Test file.
 	Lineno           int      // Line number of first output line.
 }
 
@@ -111,7 +110,6 @@ func ParseTest(r io.Reader, path string) (test Test, err error) {
 			cmd := Command{
 				CmdLine: line,
 				Lineno:  lineno + 1,
-				Path:    path,
 			}
 			test.Cmds = append(test.Cmds, cmd)
 			state = inCommand

--- a/cram.go
+++ b/cram.go
@@ -38,10 +38,15 @@ type ExecutedCommand struct {
 	ActualExitCode int      // Exit code.
 }
 
-type Result struct {
-	Commands []ExecutedCommand // The executed commands.
-	Script   string            // The script passed to the shell.
-	Failures []ExecutedCommand // Failed commands.
+// ExecutedTest captures the executed commands, the script sent to the
+// shell and the failed commands. The Test struct is embedded as a
+// value instead of pointer to make the zero value for ExecutedTest
+// immediatedly useful.
+type ExecutedTest struct {
+	Test
+	ExecutedCmds []ExecutedCommand // All executed commands.
+	Script       string            // The script passed to the shell.
+	Failures     []ExecutedCommand // Failed commands.
 }
 
 // DropEol removes a final end-of-line from s. It removes both Unix ("\n")
@@ -247,7 +252,7 @@ func Patch(r io.Reader, w io.Writer, cmds []ExecutedCommand) (err error) {
 
 // Process parses a .t file, executes the test commands and compares
 // the actual output to the expected output.
-func Process(tempdir, path string) (result Result, err error) {
+func Process(tempdir, path string) (result ExecutedTest, err error) {
 	fp, err := os.Open(path)
 	if err != nil {
 		return
@@ -279,7 +284,7 @@ func Process(tempdir, path string) (result Result, err error) {
 	}
 
 	failures := filterFailures(executed)
-	result = Result{executed, strings.Join(lines, ""),
+	result = ExecutedTest{test, executed, strings.Join(lines, ""),
 		failures}
 	return
 }

--- a/cram.go
+++ b/cram.go
@@ -37,6 +37,20 @@ type Result struct {
 	Failures []ExecutedCommand // Failed commands.
 }
 
+// DropEol removes a final end-of-line from s. It removes both Unix ("\n")
+// and DOS ("\r\n") end-of-line characters.
+func DropEol(s string) string {
+	l := len(s)
+	if l == 0 || s[l-1] != '\n' {
+		return s
+	}
+	drop := 1
+	if l > 1 && s[l-2] == '\r' {
+		drop = 2
+	}
+	return s[:l-drop]
+}
+
 // updateExitCode looks at the last line of output and updates exit
 // code if it is of the form [n]. The exit code line is only required
 // for non-zero exit codes.

--- a/cram_test.go
+++ b/cram_test.go
@@ -56,8 +56,8 @@ func TestParseNoOutput(t *testing.T) {
 	cmds, err := ParseTest(buf, "<string>")
 	assert.NoError(err)
 	if assert.Len(cmds, 2) {
-		assert.Equal(Command{"touch foo", nil, 0, "<string>", 2}, cmds[0])
-		assert.Equal(Command{"touch bar", nil, 0, "<string>", 3}, cmds[1])
+		assert.Equal(Command{"touch foo\n", nil, 0, "<string>", 2}, cmds[0])
+		assert.Equal(Command{"touch bar\n", nil, 0, "<string>", 3}, cmds[1])
 	}
 }
 
@@ -75,13 +75,13 @@ func TestParseCommands(t *testing.T) {
 
 	if assert.Len(cmds, 2) {
 		assert.Equal(Command{
-			`echo "hello\nworld"`,
-			[]string{"hello", "world"},
+			"echo \"hello\\nworld\"\n",
+			[]string{"hello\n", "world\n"},
 			0, "<string>", 2,
 		}, cmds[0])
 		assert.Equal(Command{
-			"echo goodbye",
-			[]string{"goodbye"},
+			"echo goodbye\n",
+			[]string{"goodbye\n"},
 			0, "<string>", 5,
 		}, cmds[1])
 	}
@@ -114,19 +114,20 @@ Mixture of commands and output:
 	assert.NoError(err)
 
 	if assert.Len(cmds, 5) {
-		assert.Equal(Command{"false", []string{}, 1, "<string>", 4},
+		assert.Equal(Command{
+			"false\n", []string{}, 1, "<string>", 4},
 			cmds[0])
 		assert.Equal(Command{
-			"echo hello; false", []string{"hello"}, 1, "<string>", 9},
+			"echo hello; false\n", []string{"hello\n"}, 1, "<string>", 9},
 			cmds[1])
 		assert.Equal(Command{
-			"false", []string{}, 1, "<string>", 15},
+			"false\n", []string{}, 1, "<string>", 15},
 			cmds[2])
 		assert.Equal(Command{
-			"true", nil, 0, "<string>", 17},
+			"true\n", nil, 0, "<string>", 17},
 			cmds[3])
 		assert.Equal(Command{
-			"echo hello; false", []string{"hello"}, 1, "<string>", 18},
+			"echo hello; false\n", []string{"hello\n"}, 1, "<string>", 18},
 			cmds[4])
 	}
 }
@@ -147,7 +148,7 @@ func TestMakeScript(t *testing.T) {
 		{"touch foo.txt", nil, 0, "<string>", 0},
 	}
 	lines := MakeScript(cmds, MakeBanner(u))
-	banner := `echo "--- CRAM 12345678-1234-abcd-1234-123412345678 --- $?"`
+	banner := "echo \"--- CRAM 12345678-1234-abcd-1234-123412345678 --- $?\"\n"
 	if assert.Len(t, lines, 4) {
 		assert.Equal(t, "ls", lines[0])
 		assert.Equal(t, banner, lines[1])
@@ -191,9 +192,9 @@ bar
 	executed, err := ParseOutput(cmds, output, banner)
 	assert.NoError(t, err)
 	if assert.Len(t, executed, 2) {
-		assert.Equal(t, []string{"foo"}, executed[0].ActualOutput)
+		assert.Equal(t, []string{"foo\n"}, executed[0].ActualOutput)
 		assert.Equal(t, 0, executed[0].ActualExitCode)
-		assert.Equal(t, []string{"bar"}, executed[1].ActualOutput)
+		assert.Equal(t, []string{"bar\n"}, executed[1].ActualOutput)
 		assert.Equal(t, 1, executed[1].ActualExitCode)
 	}
 }

--- a/cram_test.go
+++ b/cram_test.go
@@ -59,8 +59,8 @@ func TestParseNoOutput(t *testing.T) {
 	cmds := test.Cmds
 	assert.NoError(err)
 	if assert.Len(cmds, 2) {
-		assert.Equal(Command{"touch foo\n", nil, 0, "<string>", 2}, cmds[0])
-		assert.Equal(Command{"touch bar\n", nil, 0, "<string>", 3}, cmds[1])
+		assert.Equal(Command{"touch foo\n", nil, 0, 2}, cmds[0])
+		assert.Equal(Command{"touch bar\n", nil, 0, 3}, cmds[1])
 	}
 }
 
@@ -81,12 +81,12 @@ func TestParseCommands(t *testing.T) {
 		assert.Equal(Command{
 			"echo \"hello\\nworld\"\n",
 			[]string{"hello\n", "world\n"},
-			0, "<string>", 2,
+			0, 2,
 		}, cmds[0])
 		assert.Equal(Command{
 			"echo goodbye\n",
 			[]string{"goodbye\n"},
-			0, "<string>", 5,
+			0, 5,
 		}, cmds[1])
 	}
 }
@@ -120,19 +120,19 @@ Mixture of commands and output:
 	cmds := test.Cmds
 	if assert.Len(cmds, 5) {
 		assert.Equal(Command{
-			"false\n", []string{}, 1, "<string>", 4},
+			"false\n", []string{}, 1, 4},
 			cmds[0])
 		assert.Equal(Command{
-			"echo hello; false\n", []string{"hello\n"}, 1, "<string>", 9},
+			"echo hello; false\n", []string{"hello\n"}, 1, 9},
 			cmds[1])
 		assert.Equal(Command{
-			"false\n", []string{}, 1, "<string>", 15},
+			"false\n", []string{}, 1, 15},
 			cmds[2])
 		assert.Equal(Command{
-			"true\n", nil, 0, "<string>", 17},
+			"true\n", nil, 0, 17},
 			cmds[3])
 		assert.Equal(Command{
-			"echo hello; false\n", []string{"hello\n"}, 1, "<string>", 18},
+			"echo hello; false\n", []string{"hello\n"}, 1, 18},
 			cmds[4])
 	}
 }
@@ -149,8 +149,8 @@ func TestMakeScript(t *testing.T) {
 	u, err := uuid.FromString("123456781234abcd1234123412345678")
 	assert.NoError(t, err)
 	cmds := []Command{
-		{"ls", nil, 0, "<string>", 0},
-		{"touch foo.txt", nil, 0, "<string>", 0},
+		{"ls", nil, 0, 0},
+		{"touch foo.txt", nil, 0, 0},
 	}
 	lines := MakeScript(cmds, MakeBanner(u))
 	banner := "echo \"--- CRAM 12345678-1234-abcd-1234-123412345678 --- $?\"\n"
@@ -164,8 +164,8 @@ func TestMakeScript(t *testing.T) {
 
 func TestParseOutputEmpty(t *testing.T) {
 	cmds := []Command{
-		{"touch foo", nil, 0, "<string>", 0},
-		{"touch bar", nil, 0, "<string>", 0},
+		{"touch foo", nil, 0, 0},
+		{"touch bar", nil, 0, 0},
 	}
 	banner := "--- CRAM 12345678-1234-abcd-1234-123412345678 ---"
 	output := []byte(`--- CRAM 12345678-1234-abcd-1234-123412345678 --- 0
@@ -184,8 +184,8 @@ func TestParseOutputEmpty(t *testing.T) {
 
 func TestParseOutput(t *testing.T) {
 	cmds := []Command{
-		{"echo foo", []string{"foo"}, 0, "<string>", 0},
-		{"echo bar", []string{"bar"}, 0, "<string>", 0},
+		{"echo foo", []string{"foo"}, 0, 0},
+		{"echo bar", []string{"bar"}, 0, 0},
 	}
 	banner := "--- CRAM 12345678-1234-abcd-1234-123412345678 ---"
 	output := []byte(`foo

--- a/cram_test.go
+++ b/cram_test.go
@@ -1,12 +1,35 @@
 package cram
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestDropEol(t *testing.T) {
+	var tests = []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"\n", ""},
+		{"\r\n", ""},
+		{"foo", "foo"},
+		{"foo\n", "foo"},
+		{"foo\r\n", "foo"},
+		{"foo\nbar", "foo\nbar"},
+		{"foo\r\nbar", "foo\r\nbar"},
+	}
+
+	for _, test := range tests {
+		actual := DropEol(test.input)
+		assert.Equal(t, test.expected, actual,
+			fmt.Sprintf("DropEol(%#v)", test.input))
+	}
+}
 
 func TestParseEmpty(t *testing.T) {
 	buf := strings.NewReader("")

--- a/cram_test.go
+++ b/cram_test.go
@@ -33,18 +33,20 @@ func TestDropEol(t *testing.T) {
 
 func TestParseEmpty(t *testing.T) {
 	buf := strings.NewReader("")
-	cmds, err := ParseTest(buf, "<string>")
+	test, err := ParseTest(buf, "<string>")
 
 	assert.NoError(t, err)
-	assert.Len(t, cmds, 0)
+	assert.Equal(t, test.Path, "<string>")
+	assert.Len(t, test.Cmds, 0)
 }
 
 func TestParseCommentaryOnly(t *testing.T) {
 	buf := strings.NewReader("This file only has\nsome commentary.\n")
-	cmds, err := ParseTest(buf, "<string>")
+	test, err := ParseTest(buf, "<string>")
 
 	assert.NoError(t, err)
-	assert.Len(t, cmds, 0)
+	assert.Equal(t, test.Path, "<string>")
+	assert.Len(t, test.Cmds, 0)
 }
 
 func TestParseNoOutput(t *testing.T) {
@@ -53,7 +55,8 @@ func TestParseNoOutput(t *testing.T) {
   $ touch foo
   $ touch bar
 `)
-	cmds, err := ParseTest(buf, "<string>")
+	test, err := ParseTest(buf, "<string>")
+	cmds := test.Cmds
 	assert.NoError(err)
 	if assert.Len(cmds, 2) {
 		assert.Equal(Command{"touch foo\n", nil, 0, "<string>", 2}, cmds[0])
@@ -70,9 +73,10 @@ func TestParseCommands(t *testing.T) {
   $ echo goodbye
   goodbye
 `)
-	cmds, err := ParseTest(buf, "<string>")
+	test, err := ParseTest(buf, "<string>")
 	assert.NoError(err)
 
+	cmds := test.Cmds
 	if assert.Len(cmds, 2) {
 		assert.Equal(Command{
 			"echo \"hello\\nworld\"\n",
@@ -110,9 +114,10 @@ Mixture of commands and output:
   hello
   [1]
 `)
-	cmds, err := ParseTest(buf, "<string>")
+	test, err := ParseTest(buf, "<string>")
 	assert.NoError(err)
 
+	cmds := test.Cmds
 	if assert.Len(cmds, 5) {
 		assert.Equal(Command{
 			"false\n", []string{}, 1, "<string>", 4},

--- a/tests/interactive.t
+++ b/tests/interactive.t
@@ -1,0 +1,88 @@
+The --interactive flag does nothing if there are no test failures:
+
+  $ touch empty.t
+  $ cram --interactive empty.t
+  .
+  # Ran 1 tests (0 commands), 0 errors, 0 failures.
+
+When there are test failures, you're prompted to accept changes one at
+a time:
+
+  $ echo '  $ echo foo' >> test.t
+  $ echo '  bar'        >> test.t
+
+  $ echo y | cram --interactive test.t
+  F
+  When executing "echo foo", got
+    foo
+  but expected
+    bar
+  Accept changed output? Patched test.t
+  # Ran 1 tests (1 commands), 0 errors, 1 failures.
+  [1]
+
+Patching updates the original .t file:
+
+  $ cat test.t
+    $ echo foo
+    foo
+
+When there are multiple failures, you can update just some of them:
+
+  $ echo '  $ echo foo' >> multiple.t
+  $ echo '  first'      >> multiple.t
+  $ echo '  $ echo bar' >> multiple.t
+  $ echo '  second'     >> multiple.t
+  $ echo '  $ echo baz' >> multiple.t
+  $ echo '  third'      >> multiple.t
+
+Here we accept the 'foo' and 'baz' outputs:
+
+  $ echo "y\nn\ny" | cram --interactive multiple.t
+  F
+  When executing "echo foo", got
+    foo
+  but expected
+    first
+  Accept changed output? When executing "echo bar", got
+    bar
+  but expected
+    second
+  Accept changed output? When executing "echo baz", got
+    baz
+  but expected
+    third
+  Accept changed output? Patched multiple.t
+  # Ran 1 tests (3 commands), 0 errors, 1 failures.
+  [1]
+
+  $ cat multiple.t
+    $ echo foo
+    foo
+    $ echo bar
+    second
+    $ echo baz
+    baz
+
+Not answering 'yes'/'no' or 'y'/'n' causes the prompt to be shown
+again:
+
+  $ echo something else | cram --interactive multiple.t
+  F
+  When executing "echo bar", got
+    bar
+  but expected
+    second
+  Accept changed output? Please answer 'yes' or 'no'
+  Accept changed output? # Ran 1 tests (3 commands), 0 errors, 1 failures.
+  [1]
+
+The file was not updated in this case:
+
+  $ cat multiple.t
+    $ echo foo
+    foo
+    $ echo bar
+    second
+    $ echo baz
+    baz


### PR DESCRIPTION
This flag makes it very easy to write test files: you write the commands without output and then run `cram --interactive` once to record the answers. As you iterate on the scenario in the test file, you can use `cram --interactive` to update the outputs until things look like you want.
