### PR TITLE
Test using '  ' and fix typo in error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 cram.test
 *-fuzz.zip
+tests/fuzz/corpus/
+tests/fuzz/crashers/
+tests/fuzz/suppressions/

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -136,7 +136,7 @@ func run(ctx *cli.Context) {
 
 	processFailures(failures, ctx.GlobalBool("interactive"))
 
-	fmt.Printf("# Ran %d tests (%d commands), %d errors, %d failures.\n",
+	fmt.Printf("# Ran %d tests (%d commands), %d errors, %d failures\n",
 		len(ctx.Args()), cmdCount, errors, len(failures))
 
 	switch {

--- a/cram.go
+++ b/cram.go
@@ -126,7 +126,7 @@ func ParseTest(r io.Reader, path string) (test Test, err error) {
 		case strings.HasPrefix(line, outputPrefix):
 			if state == inCommentary {
 				err = &InvalidTestError{path, lineno,
-					fmt.Sprintf("Output line %q has no command.", line)}
+					fmt.Sprintf("Output line %q has no command", line)}
 				return
 			}
 			line = line[len(outputPrefix):]

--- a/cram.go
+++ b/cram.go
@@ -126,7 +126,7 @@ func ParseTest(r io.Reader, path string) (test Test, err error) {
 		case strings.HasPrefix(line, outputPrefix):
 			if state == inCommentary {
 				err = &InvalidTestError{path, lineno,
-					fmt.Sprintf("Output line %q has not command.", line)}
+					fmt.Sprintf("Output line %q has no command.", line)}
 				return
 			}
 			line = line[len(outputPrefix):]

--- a/cram_test.go
+++ b/cram_test.go
@@ -44,7 +44,7 @@ func TestParseOutputOnly(t *testing.T) {
 	buf := strings.NewReader("\n\n  \n")
 	test, err := ParseTest(buf, "<string>")
 
-	assert.EqualError(t, err, `<string>:2: Output line "  \n" has no command.`)
+	assert.EqualError(t, err, `<string>:2: Output line "  \n" has no command`)
 	assert.Len(t, test.Cmds, 0)
 }
 

--- a/cram_test.go
+++ b/cram_test.go
@@ -44,7 +44,7 @@ func TestParseOutputOnly(t *testing.T) {
 	buf := strings.NewReader("\n\n  \n")
 	test, err := ParseTest(buf, "<string>")
 
-	assert.EqualError(t, err, `<string>:2: Output line "  \n" has not command.`)
+	assert.EqualError(t, err, `<string>:2: Output line "  \n" has no command.`)
 	assert.Len(t, test.Cmds, 0)
 }
 

--- a/fuzz.sh
+++ b/fuzz.sh
@@ -7,7 +7,7 @@ go get -v github.com/dvyukov/go-fuzz/go-fuzz-build
 echo "Instrumenting Cram"
 go-fuzz-build github.com/mgeisler/cram/tests/fuzz
 
-mkdir tests/fuzz/corpus
+mkdir -p tests/fuzz/corpus
 cp tests/*.t tests/fuzz/corpus
 
 echo "Starting fuzz test"

--- a/fuzz.sh
+++ b/fuzz.sh
@@ -22,6 +22,7 @@ for path in tests/fuzz/crashers/*.quoted; do
         cat "$path"
         echo "Output:"
         cat "${path%.quoted}.output"
+        echo
     fi
 done
 

--- a/tests/exit-codes.t
+++ b/tests/exit-codes.t
@@ -3,7 +3,7 @@ Cram will normally exit with a status of 0 to indicate success:
   $ touch empty.t
   $ cram empty.t
   .
-  # Ran 1 tests (0 commands), 0 errors, 0 failures.
+  # Ran 1 tests (0 commands), 0 errors, 0 failures
 
 Test failures set the exit code to 1:
 
@@ -14,7 +14,7 @@ Test failures set the exit code to 1:
     foo
   but expected
     
-  # Ran 2 tests (1 commands), 0 errors, 1 failures.
+  # Ran 2 tests (1 commands), 0 errors, 1 failures
   [1]
 
 If an error occurs, the error is shown, the error count incremented,
@@ -27,7 +27,7 @@ and the exit code is set to 2:
     foo
   but expected
     
-  # Ran 3 tests (1 commands), 1 errors, 1 failures.
+  # Ran 3 tests (1 commands), 1 errors, 1 failures
   [2]
 
 A command with no output can also have a non-zero exit code:
@@ -47,5 +47,5 @@ Mismatches in exit codes are shown in the Cram output:
   F
   When executing "false", got
     exit code 1, but expected 0
-  # Ran 1 tests (1 commands), 0 errors, 1 failures.
+  # Ran 1 tests (1 commands), 0 errors, 1 failures
   [1]

--- a/tests/failures.t
+++ b/tests/failures.t
@@ -8,5 +8,5 @@ Cram shows the failed command with the actual and expected output:
     foo
   but expected
     bar
-  # Ran 1 tests (1 commands), 0 errors, 1 failures.
+  # Ran 1 tests (1 commands), 0 errors, 1 failures
   [1]

--- a/tests/interactive.t
+++ b/tests/interactive.t
@@ -3,7 +3,7 @@ The --interactive flag does nothing if there are no test failures:
   $ touch empty.t
   $ cram --interactive empty.t
   .
-  # Ran 1 tests (0 commands), 0 errors, 0 failures.
+  # Ran 1 tests (0 commands), 0 errors, 0 failures
 
 When there are test failures, you're prompted to accept changes one at
 a time:
@@ -18,7 +18,7 @@ a time:
   but expected
     bar
   Accept changed output? Patched test.t
-  # Ran 1 tests (1 commands), 0 errors, 1 failures.
+  # Ran 1 tests (1 commands), 0 errors, 1 failures
   [1]
 
 Patching updates the original .t file:
@@ -53,7 +53,7 @@ Here we accept the 'foo' and 'baz' outputs:
   but expected
     third
   Accept changed output? Patched multiple.t
-  # Ran 1 tests (3 commands), 0 errors, 1 failures.
+  # Ran 1 tests (3 commands), 0 errors, 1 failures
   [1]
 
   $ cat multiple.t
@@ -74,7 +74,7 @@ again:
   but expected
     second
   Accept changed output? Please answer 'yes' or 'no'
-  Accept changed output? # Ran 1 tests (3 commands), 0 errors, 1 failures.
+  Accept changed output? # Ran 1 tests (3 commands), 0 errors, 1 failures
   [1]
 
 The file was not updated in this case:

--- a/tests/invalid.t
+++ b/tests/invalid.t
@@ -2,9 +2,9 @@ Parsing a file with an output line before any command lines:
 
   $ echo '  This is an output line' > test.t
   $ cram test.t
-  test.t:0: Output line "  This is an output line\n" has no command.
+  test.t:0: Output line "  This is an output line\n" has no command
   E
-  # Ran 1 tests (0 commands), 1 errors, 0 failures.
+  # Ran 1 tests (0 commands), 1 errors, 0 failures
   [2]
 
 Parsing a file with a command and with an output line immediated after
@@ -16,16 +16,16 @@ a commentary line:
   $ echo '  Output line'  >> test.t
 
   $ cram test.t
-  test.t:3: Output line "  Output line\n" has no command.
+  test.t:3: Output line "  Output line\n" has no command
   E
-  # Ran 1 tests (0 commands), 1 errors, 0 failures.
+  # Ran 1 tests (0 commands), 1 errors, 0 failures
   [2]
 
 Parse invalid file with no final newline:
 
   $ echo -n '  ' > test.t
   $ cram test.t
-  test.t:0: Output line "  " has no command.
+  test.t:0: Output line "  " has no command
   E
-  # Ran 1 tests (0 commands), 1 errors, 0 failures.
+  # Ran 1 tests (0 commands), 1 errors, 0 failures
   [2]

--- a/tests/invalid.t
+++ b/tests/invalid.t
@@ -2,7 +2,7 @@ Parsing a file with an output line before any command lines:
 
   $ echo '  This is an output line' > test.t
   $ cram test.t
-  test.t:0: Output line "  This is an output line\n" has not command.
+  test.t:0: Output line "  This is an output line\n" has no command.
   E
   # Ran 1 tests (0 commands), 1 errors, 0 failures.
   [2]
@@ -16,7 +16,7 @@ a commentary line:
   $ echo '  Output line'  >> test.t
 
   $ cram test.t
-  test.t:3: Output line "  Output line\n" has not command.
+  test.t:3: Output line "  Output line\n" has no command.
   E
   # Ran 1 tests (0 commands), 1 errors, 0 failures.
   [2]
@@ -25,7 +25,7 @@ Parse invalid file with no final newline:
 
   $ echo -n '  ' > test.t
   $ cram test.t
-  test.t:0: Output line "  " has not command.
+  test.t:0: Output line "  " has no command.
   E
   # Ran 1 tests (0 commands), 1 errors, 0 failures.
   [2]

--- a/tests/invalid.t
+++ b/tests/invalid.t
@@ -20,3 +20,12 @@ a commentary line:
   E
   # Ran 1 tests (0 commands), 1 errors, 0 failures.
   [2]
+
+Parse invalid file with no final newline:
+
+  $ echo -n '  ' > test.t
+  $ cram test.t
+  test.t:0: Output line "  " has not command.
+  E
+  # Ran 1 tests (0 commands), 1 errors, 0 failures.
+  [2]


### PR DESCRIPTION
Small cleanups to the fuzz testing:
- add a test using the input found using the fuzz tester
- fix a typo in the error message
- cleanup output
- ignore the directories created by `fuzz.sh`
