### PR TITLE
ProcessFailures: show diff of output

### DIFF
--- a/tests/exit-codes.t
+++ b/tests/exit-codes.t
@@ -10,10 +10,8 @@ Test failures set the exit code to 1:
   $ echo '  $ echo foo' >> extra-output.t
   $ cram *.t
   .F
-  When executing "echo foo", got
-    foo
-  but expected
-    
+  When executing "echo foo", output changed:
+  +foo
   # Ran 2 tests (1 commands), 0 errors, 1 failures
   [1]
 
@@ -23,10 +21,8 @@ and the exit code is set to 2:
   $ cram does-not-exist.t *.t
   open does-not-exist.t: no such file or directory
   E.F
-  When executing "echo foo", got
-    foo
-  but expected
-    
+  When executing "echo foo", output changed:
+  +foo
   # Ran 3 tests (1 commands), 1 errors, 1 failures
   [2]
 
@@ -45,7 +41,6 @@ Mismatches in exit codes are shown in the Cram output:
   $ echo '  $ false' >> false.t
   $ cram false.t
   F
-  When executing "false", got
-    exit code 1, but expected 0
+  When executing "false", exit code changed from 0 to 1
   # Ran 1 tests (1 commands), 0 errors, 1 failures
   [1]

--- a/tests/failures.t
+++ b/tests/failures.t
@@ -10,3 +10,24 @@ actual output:
   +foo
   # Ran 1 tests (1 commands), 0 errors, 1 failures
   [1]
+
+Unexpected output:
+
+  $ echo '  $ echo foo' > unexpected.t
+  $ cram unexpected.t
+  F
+  When executing "echo foo", output changed:
+  +foo
+  # Ran 1 tests (1 commands), 0 errors, 1 failures
+  [1]
+
+Missing output:
+
+  $ echo '  $ true'  >> missing.t
+  $ echo '  missing' >> missing.t
+  $ cram missing.t
+  F
+  When executing "true", output changed:
+  -missing
+  # Ran 1 tests (1 commands), 0 errors, 1 failures
+  [1]

--- a/tests/failures.t
+++ b/tests/failures.t
@@ -1,12 +1,12 @@
-Cram shows the failed command with the actual and expected output:
+Cram shows the failed command with a diff between the expected and
+actual output:
 
   $ echo '  $ echo foo' >> test.t
   $ echo '  bar'        >> test.t
   $ cram test.t
   F
-  When executing "echo foo", got
-    foo
-  but expected
-    bar
+  When executing "echo foo", output changed:
+  -bar
+  +foo
   # Ran 1 tests (1 commands), 0 errors, 1 failures
   [1]

--- a/tests/interactive.t
+++ b/tests/interactive.t
@@ -13,10 +13,9 @@ a time:
 
   $ echo y | cram --interactive test.t
   F
-  When executing "echo foo", got
-    foo
-  but expected
-    bar
+  When executing "echo foo", output changed:
+  -bar
+  +foo
   Accept changed output? Patched test.t
   # Ran 1 tests (1 commands), 0 errors, 1 failures
   [1]
@@ -40,18 +39,15 @@ Here we accept the 'foo' and 'baz' outputs:
 
   $ echo "y\nn\ny" | cram --interactive multiple.t
   F
-  When executing "echo foo", got
-    foo
-  but expected
-    first
-  Accept changed output? When executing "echo bar", got
-    bar
-  but expected
-    second
-  Accept changed output? When executing "echo baz", got
-    baz
-  but expected
-    third
+  When executing "echo foo", output changed:
+  -first
+  +foo
+  Accept changed output? When executing "echo bar", output changed:
+  -second
+  +bar
+  Accept changed output? When executing "echo baz", output changed:
+  -third
+  +baz
   Accept changed output? Patched multiple.t
   # Ran 1 tests (3 commands), 0 errors, 1 failures
   [1]
@@ -69,10 +65,9 @@ again:
 
   $ echo something else | cram --interactive multiple.t
   F
-  When executing "echo bar", got
-    bar
-  but expected
-    second
+  When executing "echo bar", output changed:
+  -second
+  +bar
   Accept changed output? Please answer 'yes' or 'no'
   Accept changed output? # Ran 1 tests (3 commands), 0 errors, 1 failures
   [1]


### PR DESCRIPTION
Instead of showing the expected and actual output as two separate pieces
of text, we now show a unified diff instead.

The diff is not minimized, which means that all common lines are shown.
This is like saying to diff(1) that you want a very large context. This
might be okay for command line output, which is typically short.

Also, assuming the test files are under version control, there is an
easy work-around: use --interactive and run the diff command of your
version control system afterwards. That will give you a diff with the
common lines trimmed.
