### PR TITLE
main: include exit code in diff

### DIFF
--- a/tests/exit-codes.t
+++ b/tests/exit-codes.t
@@ -10,7 +10,7 @@ Test failures set the exit code to 1:
   $ echo '  $ echo foo' >> extra-output.t
   $ cram *.t
   .F
-  When executing "echo foo", output changed:
+  When executing "echo foo":
   +foo
   # Ran 2 tests (1 commands), 0 errors, 1 failures
   [1]
@@ -21,7 +21,7 @@ and the exit code is set to 2:
   $ cram does-not-exist.t *.t
   open does-not-exist.t: no such file or directory
   E.F
-  When executing "echo foo", output changed:
+  When executing "echo foo":
   +foo
   # Ran 3 tests (1 commands), 1 errors, 1 failures
   [2]
@@ -41,6 +41,7 @@ Mismatches in exit codes are shown in the Cram output:
   $ echo '  $ false' >> false.t
   $ cram false.t
   F
-  When executing "false", exit code changed from 0 to 1
+  When executing "false":
+  +[1]
   # Ran 1 tests (1 commands), 0 errors, 1 failures
   [1]

--- a/tests/failures.t
+++ b/tests/failures.t
@@ -5,7 +5,7 @@ actual output:
   $ echo '  bar'        >> test.t
   $ cram test.t
   F
-  When executing "echo foo", output changed:
+  When executing "echo foo":
   -bar
   +foo
   # Ran 1 tests (1 commands), 0 errors, 1 failures
@@ -16,7 +16,7 @@ Unexpected output:
   $ echo '  $ echo foo' > unexpected.t
   $ cram unexpected.t
   F
-  When executing "echo foo", output changed:
+  When executing "echo foo":
   +foo
   # Ran 1 tests (1 commands), 0 errors, 1 failures
   [1]
@@ -27,7 +27,7 @@ Missing output:
   $ echo '  missing' >> missing.t
   $ cram missing.t
   F
-  When executing "true", output changed:
+  When executing "true":
   -missing
   # Ran 1 tests (1 commands), 0 errors, 1 failures
   [1]

--- a/tests/interactive.t
+++ b/tests/interactive.t
@@ -13,10 +13,10 @@ a time:
 
   $ echo y | cram --interactive test.t
   F
-  When executing "echo foo", output changed:
+  When executing "echo foo":
   -bar
   +foo
-  Accept changed output? Patched test.t
+  Accept this change? Patched test.t
   # Ran 1 tests (1 commands), 0 errors, 1 failures
   [1]
 
@@ -39,16 +39,16 @@ Here we accept the 'foo' and 'baz' outputs:
 
   $ echo "y\nn\ny" | cram --interactive multiple.t
   F
-  When executing "echo foo", output changed:
+  When executing "echo foo":
   -first
   +foo
-  Accept changed output? When executing "echo bar", output changed:
+  Accept this change? When executing "echo bar":
   -second
   +bar
-  Accept changed output? When executing "echo baz", output changed:
+  Accept this change? When executing "echo baz":
   -third
   +baz
-  Accept changed output? Patched multiple.t
+  Accept this change? Patched multiple.t
   # Ran 1 tests (3 commands), 0 errors, 1 failures
   [1]
 
@@ -65,11 +65,11 @@ again:
 
   $ echo something else | cram --interactive multiple.t
   F
-  When executing "echo bar", output changed:
+  When executing "echo bar":
   -second
   +bar
-  Accept changed output? Please answer 'yes' or 'no'
-  Accept changed output? # Ran 1 tests (3 commands), 0 errors, 1 failures
+  Accept this change? Please answer 'yes' or 'no'
+  Accept this change? # Ran 1 tests (3 commands), 0 errors, 1 failures
   [1]
 
 The file was not updated in this case:
@@ -81,3 +81,36 @@ The file was not updated in this case:
     second
     $ echo baz
     baz
+
+You will also be prompted to update the exit code:
+
+  $ echo 'Wrong exit code'                  >> exit-code.t
+  $ echo '  $ (exit 7)'                     >> exit-code.t
+  $ echo '  [10]'                           >> exit-code.t
+  $ echo 'Missing non-zero exit code:'      >> exit-code.t
+  $ echo '  $ false'                        >> exit-code.t
+  $ echo 'White-space after the exit code:' >> exit-code.t
+  $ echo '  $ true'                         >> exit-code.t
+  $ echo '  [42]   '                        >> exit-code.t
+  $ yes | cram --interactive exit-code.t
+  F
+  When executing "(exit 7)":
+  -[10]
+  +[7]
+  Accept this change? When executing "false":
+  +[1]
+  Accept this change? When executing "true":
+  -[42]   
+  Accept this change? Patched exit-code.t
+  # Ran 1 tests (3 commands), 0 errors, 1 failures
+  [1]
+
+  $ cat exit-code.t
+  Wrong exit code
+    $ (exit 7)
+    [7]
+  Missing non-zero exit code:
+    $ false
+    [1]
+  White-space after the exit code:
+    $ true


### PR DESCRIPTION
Before we only showed a message when the actual exit code didn't match
the expected exit code. We now include the exit code in the diff and
allow the user to patch it when --interactive is used.

The output format changed slightly since we now have just one prompt or
message for each test failure.
