### PR TITLE
Add --jobs flag

### DIFF
--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -165,25 +165,25 @@ func run(ctx *cli.Context) {
 	}()
 
 	for i := 0; i < len(ctx.Args()); i++ {
-		processResult := <-results
-		result := processResult.Test
-		err := processResult.Err
+		result := <-results
+		test := result.Test
+		err := result.Err
 
 		if ctx.GlobalBool("debug") {
-			fmt.Fprintf(os.Stderr, "# %s\n", result.Path)
-			fmt.Fprintln(os.Stderr, result.Script)
+			fmt.Fprintf(os.Stderr, "# %s\n", test.Path)
+			fmt.Fprintln(os.Stderr, test.Script)
 		}
 
-		cmdCount += len(result.Cmds)
+		cmdCount += len(test.Cmds)
 
 		switch {
 		case err != nil:
 			fmt.Fprintln(os.Stderr, err)
 			fmt.Print("E")
 			errors++
-		case len(result.Failures) > 0:
+		case len(test.Failures) > 0:
 			fmt.Print("F")
-			failures = append(failures, result)
+			failures = append(failures, test)
 		default:
 			fmt.Print(".")
 		}

--- a/tests/exit-codes.t
+++ b/tests/exit-codes.t
@@ -8,7 +8,7 @@ Cram will normally exit with a status of 0 to indicate success:
 Test failures set the exit code to 1:
 
   $ echo '  $ echo foo' >> extra-output.t
-  $ cram *.t
+  $ cram -j 1 *.t
   .F
   When executing "echo foo":
   +foo
@@ -18,7 +18,7 @@ Test failures set the exit code to 1:
 If an error occurs, the error is shown, the error count incremented,
 and the exit code is set to 2:
 
-  $ cram does-not-exist.t *.t
+  $ cram -j 1 does-not-exist.t *.t
   open does-not-exist.t: no such file or directory
   E.F
   When executing "echo foo":

--- a/tests/help.t
+++ b/tests/help.t
@@ -12,11 +12,12 @@ Cram comes with builtin help:
      
   COMMANDS:
   GLOBAL OPTIONS:
-     --interactive  interactively update test file on failure
-     --debug        output debug information
-     --keep-tmp     keep temporary directory after executing tests
-     --help, -h     show help
-     --version, -v  print the version
+     --interactive           interactively update test file on failure
+     --debug                 output debug information
+     --keep-tmp              keep temporary directory after executing tests
+     --jobs value, -j value  number of tests to run in parallel (default: 0)
+     --help, -h              show help
+     --version, -v           print the version
      
 The traditional --version flag also works:
 

--- a/tests/help.t
+++ b/tests/help.t
@@ -18,3 +18,7 @@ Cram comes with builtin help:
      --help, -h     show help
      --version, -v  print the version
      
+The traditional --version flag also works:
+
+  $ cram --version
+  cram version 0.0.0

--- a/tests/help.t
+++ b/tests/help.t
@@ -1,0 +1,20 @@
+Cram comes with builtin help:
+
+  $ cram --help
+  NAME:
+     cram - A new cli application
+  
+  USAGE:
+     cram [global options] command [command options] [arguments...]
+     
+  VERSION:
+     0.0.0
+     
+  COMMANDS:
+  GLOBAL OPTIONS:
+     --interactive  interactively update test file on failure
+     --debug        output debug information
+     --keep-tmp     keep temporary directory after executing tests
+     --help, -h     show help
+     --version, -v  print the version
+     


### PR DESCRIPTION
With this flag, we can now run tests in parallel. By default, Cram runs uses `2 * runtime.NumCPU` tests in parallel. That number gave the fastest execution time with the Mercurial test runner.

This fixes #20.
