### PR TITLE
tests: run "cram tests/*.t" via "go test"

### DIFF
--- a/self_test.go
+++ b/self_test.go
@@ -1,0 +1,23 @@
+package cram
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestSelf runs Cram on all .t files inside the tests directory.
+func TestSelf(t *testing.T) {
+	paths, err := filepath.Glob("tests/*.t")
+	if err != nil {
+		t.Fatal("Error while globbing:", err)
+	}
+
+	cmd := exec.Command("cram", paths...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log("Cram failed:", err)
+		t.Log(string(output))
+		t.Fail()
+	}
+}

--- a/shippable.yml
+++ b/shippable.yml
@@ -15,7 +15,6 @@ build:
     - cat gotest.out
     - go-junit-report < gotest.out > shippable/testresults/gotest.xml
     - go vet ./...
-    - cram tests/*.t
 
     # Fuzz testing
     - 'if [ "$SHIPPABLE_GO_VERSION" = "1.6" ]; then ./fuzz.sh; fi'


### PR DESCRIPTION
This integrates the self-tests with the normal "go test" mechanism,
making it easier for everybody to remember to run these tests.
