### PR TITLE
Add support for (re) and (glob) output lines

### DIFF
--- a/cram.go
+++ b/cram.go
@@ -64,9 +64,15 @@ func (cmd *ExecutedCommand) failed() bool {
 	if cmd.ActualExitCode != cmd.ExpectedExitCode {
 		return true
 	}
-	actual := strings.Join(cmd.ActualOutput, "")
-	expected := strings.Join(cmd.ExpectedOutput, "")
-	return actual != expected
+	if len(cmd.ActualOutput) != len(cmd.ExpectedOutput) {
+		return true
+	}
+	for i, actual := range cmd.ActualOutput {
+		if actual != cmd.ExpectedOutput[i] {
+			return true
+		}
+	}
+	return false
 }
 
 // DropEol removes a final end-of-line from s. It removes both Unix ("\n")

--- a/cram.go
+++ b/cram.go
@@ -137,6 +137,11 @@ func (cmd *ExecutedCommand) failed() bool {
 			if !matchEntireLine(pattern, actual) {
 				return true
 			}
+		case strings.HasSuffix(expected, globSuffix):
+			pattern := expected[:len(expected)-len(globSuffix)]
+			if !matchEntireLine(globToRegexp(pattern), actual) {
+				return true
+			}
 		default:
 			// No special suffix, not equal by the check above => we
 			// found a change in the output.

--- a/cram.go
+++ b/cram.go
@@ -260,6 +260,8 @@ func MakeScript(cmds []Command, banner string) (lines []string) {
 	return
 }
 
+// ParseOutput finds the actual output and exit codes for a slice of
+// commands. The result is a slice of executed commands.
 func ParseOutput(cmds []Command, output []byte, banner string) (
 	executed []ExecutedCommand, err error) {
 	r := bytes.NewReader(output)

--- a/cram_test.go
+++ b/cram_test.go
@@ -77,6 +77,13 @@ func TestExecutedCommandFailed(t *testing.T) {
 		Lineno:           1,
 	}
 
+	glob := Command{
+		CmdLine:          "ls",
+		ExpectedOutput:   []string{"*.jpg (glob)\n"},
+		ExpectedExitCode: 0,
+		Lineno:           1,
+	}
+
 	var tests = []struct {
 		cmd      ExecutedCommand
 		expected bool
@@ -97,6 +104,13 @@ func TestExecutedCommandFailed(t *testing.T) {
 		{ExecutedCommand{&re, []string{"hello world!"}, 0}, true},
 		{ExecutedCommand{&re, []string{"hello +world"}, 0}, true},
 		{ExecutedCommand{&badPattern, []string{"..."}, 0}, true},
+
+		// Glob patterns.
+		{ExecutedCommand{&glob, []string{"*.jpg (glob)\n"}, 0}, false},
+		{ExecutedCommand{&glob, []string{"foo.jpg\n"}, 0}, false},
+		{ExecutedCommand{&glob, []string{"foo.jpg"}, 0}, false},
+		{ExecutedCommand{&glob, []string{"foo.jpg  "}, 0}, true},
+		{ExecutedCommand{&glob, []string{"quuz.png"}, 0}, true},
 	}
 
 	for _, test := range tests {

--- a/cram_test.go
+++ b/cram_test.go
@@ -31,6 +31,32 @@ func TestDropEol(t *testing.T) {
 	}
 }
 
+func TestGlobToRegexp(t *testing.T) {
+	var tests = []struct {
+		input    string
+		expected string
+	}{
+		{``, ``},
+		{`foo`, `foo`},
+		{`foo*`, `foo.*`},
+		{`foo?`, `foo.`},
+		{`a.b`, `a\.b`},
+		{`a..b`, `a\.\.b`},
+		{`a\*b`, `a\*b`},
+		{`a\?b`, `a\?b`},
+		{`a\\*b`, `a\\.*b`},
+		{`x\`, `x`},
+		{`x\x`, `xx`},
+		{`x\n`, `xn`},
+	}
+
+	for _, test := range tests {
+		actual := globToRegexp(test.input)
+		assert.Equal(t, test.expected, actual,
+			fmt.Sprintf("globToRegexp(%#v)", test.input))
+	}
+}
+
 func TestExecutedCommandFailed(t *testing.T) {
 	cmd := Command{
 		CmdLine:          "ls",

--- a/cram_test.go
+++ b/cram_test.go
@@ -31,6 +31,31 @@ func TestDropEol(t *testing.T) {
 	}
 }
 
+func TestExecutedCommandFailed(t *testing.T) {
+	cmd := Command{
+		CmdLine:          "ls",
+		ExpectedOutput:   []string{"bar\n", "foo\n"},
+		ExpectedExitCode: 0,
+		Lineno:           1,
+	}
+
+	var tests = []struct {
+		cmd      ExecutedCommand
+		expected bool
+	}{
+		{ExecutedCommand{&cmd, []string{"bar\n", "foo\n"}, 0}, false},
+		{ExecutedCommand{&cmd, []string{"bar\n", "foo\n"}, 42}, true},
+		{ExecutedCommand{&cmd, []string{"new", "output"}, 0}, true},
+		{ExecutedCommand{&cmd, []string{"more", "lines"}, 0}, true},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expected, test.cmd.failed(),
+			fmt.Sprintf("output: %q, exit code: %d",
+				test.cmd.ActualOutput, test.cmd.ActualExitCode))
+	}
+}
+
 func TestParseEmpty(t *testing.T) {
 	buf := strings.NewReader("")
 	test, err := ParseTest(buf, "<string>")

--- a/cram_test.go
+++ b/cram_test.go
@@ -38,15 +38,39 @@ func TestExecutedCommandFailed(t *testing.T) {
 		ExpectedExitCode: 0,
 		Lineno:           1,
 	}
+	re := Command{
+		CmdLine:          "cat foo.txt",
+		ExpectedOutput:   []string{"hello +world (re)\n"},
+		ExpectedExitCode: 0,
+		Lineno:           1,
+	}
+	badPattern := Command{
+		CmdLine:          "cat foo.txt",
+		ExpectedOutput:   []string{"* (re)\n"},
+		ExpectedExitCode: 0,
+		Lineno:           1,
+	}
 
 	var tests = []struct {
 		cmd      ExecutedCommand
 		expected bool
 	}{
+		// Simple output lines.
 		{ExecutedCommand{&cmd, []string{"bar\n", "foo\n"}, 0}, false},
 		{ExecutedCommand{&cmd, []string{"bar\n", "foo\n"}, 42}, true},
 		{ExecutedCommand{&cmd, []string{"new", "output"}, 0}, true},
 		{ExecutedCommand{&cmd, []string{"more", "lines"}, 0}, true},
+
+		// Regular expressions.
+		{ExecutedCommand{&re, []string{"hello +world (re)\n"}, 0}, false},
+		{ExecutedCommand{&re, []string{"hello world\n"}, 0}, false},
+		{ExecutedCommand{&re, []string{"hello world"}, 0}, false},
+		{ExecutedCommand{&re, []string{"hello   world"}, 0}, false},
+		{ExecutedCommand{&re, []string{"hello_world"}, 0}, true},
+		{ExecutedCommand{&re, []string{"!hello world"}, 0}, true},
+		{ExecutedCommand{&re, []string{"hello world!"}, 0}, true},
+		{ExecutedCommand{&re, []string{"hello +world"}, 0}, true},
+		{ExecutedCommand{&badPattern, []string{"..."}, 0}, true},
 	}
 
 	for _, test := range tests {

--- a/tests/glob.t
+++ b/tests/glob.t
@@ -1,0 +1,34 @@
+Cram supports output lines with glob patterns:
+
+  $ echo 'hello beautiful world!'
+  hello * world? (glob)
+
+The only two special characters are "*" and "?". The "*" character
+matches any number of characters, including "/":
+
+  $ echo foo/bar/baz
+  foo*z (glob)
+
+The "?" character matches a single character:
+
+  $ echo x/y
+  x?y (glob)
+
+You can escape these characters with a backslash:
+
+  $ echo '?foo*'
+  \?foo\* (glob)
+
+The matching of actual and expected output is done line-by-line, so
+you cannot match a newline with either character:
+
+  $ echo '  $ echo 'a'; echo b' >> newline.t
+  $ echo '  a?b (glob)'         >> newline.t
+  $ cram newline.t
+  F
+  When executing "echo a; echo b":
+  -a?b (glob)
+  +a
+  +b
+  # Ran 1 tests (1 commands), 0 errors, 1 failures
+  [1]

--- a/tests/re.t
+++ b/tests/re.t
@@ -1,0 +1,41 @@
+Cram supports output lines with regular expressions:
+
+  $ echo hello beautiful world
+  hello .* world (re)
+
+  $ echo hello beautiful world
+  hello \w+ world (re)
+
+The amount of whitespace before the "(re)" is important:
+
+  $ echo 'hello world   '
+  hello.world    (re)
+
+When such a line fails, you get the diff as normal:
+
+  $ echo '  $ echo foo42' >> failure.t
+  $ echo '  [0-9]+ (re)'  >> failure.t
+  $ cram failure.t
+  F
+  When executing "echo foo42":
+  -[0-9]+ (re)
+  +foo42
+  # Ran 1 tests (1 commands), 0 errors, 1 failures
+  [1]
+
+The pattern is anchored at the beginning and the end of the line:
+
+  $ echo '  $ echo foobar' >> anchor.t
+  $ echo '  foo (re)'      >> anchor.t
+  $ echo '  $ echo foobar' >> anchor.t
+  $ echo '  bar (re)'      >> anchor.t
+  $ cram anchor.t
+  F
+  When executing "echo foobar":
+  -foo (re)
+  +foobar
+  When executing "echo foobar":
+  -bar (re)
+  +foobar
+  # Ran 1 tests (2 commands), 0 errors, 1 failures
+  [1]


### PR DESCRIPTION
Output lines can now end with `(re)` or `(glob)` to indicate that they should be matched as a regular expression or a glob pattern, respectively.