### PR TITLE
shippable: show "go test" output directly with tee

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -11,8 +11,7 @@ build:
     - go get github.com/jstemmer/go-junit-report
     - go get -t -d -v ./...
     - go install -v ./...
-    - go test -v ./... > gotest.out
-    - cat gotest.out
+    - go test -v ./... | tee gotest.out
     - go-junit-report < gotest.out > shippable/testresults/gotest.xml
     - go vet ./...
 


### PR DESCRIPTION
This will let us see the test output as it happens instead of waiting for all tests to finish.
