### PR TITLE
Add support for continuation lines

### DIFF
--- a/tests/continuations.t
+++ b/tests/continuations.t
@@ -1,0 +1,59 @@
+Commands start with "$" and can be continued on subsequent lines that
+start with ">":
+
+  $ hello () {
+  >   echo "This is the hello function"
+  >   echo "Hello $1, nice to meet you!"
+  >   return 42
+  > }
+
+We can now use the function just defined
+
+  $ hello Martin
+  This is the hello function
+  Hello Martin, nice to meet you!
+  [42]
+
+Changes in output are shown normally:
+
+  $ cat > cont.t << EOM
+  > Some text before the command
+  >   $ echo foo
+  >   > echo bar
+  >   > echo baz
+  > Some text after the command
+  > EOM
+  $ cram cont.t
+  F
+  When executing "echo foo\necho bar\necho baz":
+  +foo
+  +bar
+  +baz
+  # Ran 1 tests (1 commands), 0 errors, 1 failures
+  [1]
+
+You can patch such a command:
+
+  $ yes | cram --interactive cont.t
+  F
+  When executing "echo foo\necho bar\necho baz":
+  +foo
+  +bar
+  +baz
+  Accept this change? Patched cont.t
+  # Ran 1 tests (1 commands), 0 errors, 1 failures
+  [1]
+
+  $ cat cont.t
+  Some text before the command
+    $ echo foo
+    > echo bar
+    > echo baz
+    foo
+    bar
+    baz
+  Some text after the command
+
+  $ cram cont.t
+  .
+  # Ran 1 tests (1 commands), 0 errors, 0 failures

--- a/tests/interactive.t
+++ b/tests/interactive.t
@@ -28,12 +28,14 @@ Patching updates the original .t file:
 
 When there are multiple failures, you can update just some of them:
 
-  $ echo '  $ echo foo' >> multiple.t
-  $ echo '  first'      >> multiple.t
-  $ echo '  $ echo bar' >> multiple.t
-  $ echo '  second'     >> multiple.t
-  $ echo '  $ echo baz' >> multiple.t
-  $ echo '  third'      >> multiple.t
+  $ cat > multiple.t << EOM
+  >   $ echo foo
+  >   first
+  >   $ echo bar
+  >   second
+  >   $ echo baz
+  >   third
+  > EOM
 
 Here we accept the 'foo' and 'baz' outputs:
 
@@ -84,14 +86,16 @@ The file was not updated in this case:
 
 You will also be prompted to update the exit code:
 
-  $ echo 'Wrong exit code'                  >> exit-code.t
-  $ echo '  $ (exit 7)'                     >> exit-code.t
-  $ echo '  [10]'                           >> exit-code.t
-  $ echo 'Missing non-zero exit code:'      >> exit-code.t
-  $ echo '  $ false'                        >> exit-code.t
-  $ echo 'White-space after the exit code:' >> exit-code.t
-  $ echo '  $ true'                         >> exit-code.t
-  $ echo '  [42]   '                        >> exit-code.t
+  $ cat > exit-code.t << EOM
+  > Wrong exit code
+  >   $ (exit 7)
+  >   [10]
+  > Missing non-zero exit code:
+  >   $ false
+  > White-space after the exit code:
+  >   $ true
+  >   [42]   
+  > EOM
   $ yes | cram --interactive exit-code.t
   F
   When executing "(exit 7)":

--- a/tests/invalid.t
+++ b/tests/invalid.t
@@ -10,11 +10,12 @@ Parsing a file with an output line before any command lines:
 Parsing a file with a command and with an output line immediated after
 a commentary line:
 
-  $ echo '  $ echo hello'  > test.t
-  $ echo '  hello'        >> test.t
-  $ echo 'Commentary'     >> test.t
-  $ echo '  Output line'  >> test.t
-
+  $ cat > test.t << EOM
+  >   $ echo hello
+  >   hello
+  > Commentary
+  >   Output line
+  > EOM
   $ cram test.t
   test.t:3: Output line "  Output line\n" has no command
   E

--- a/tests/invalid.t
+++ b/tests/invalid.t
@@ -29,3 +29,12 @@ Parse invalid file with no final newline:
   E
   # Ran 1 tests (0 commands), 1 errors, 0 failures
   [2]
+
+Continuation line with no corresponding command:
+
+  $ echo '  > continued' > test.t
+  $ cram test.t
+  test.t:0: Continuation line "  > continued\n" has no command
+  E
+  # Ran 1 tests (0 commands), 1 errors, 0 failures
+  [2]

--- a/tests/re.t
+++ b/tests/re.t
@@ -25,10 +25,12 @@ When such a line fails, you get the diff as normal:
 
 The pattern is anchored at the beginning and the end of the line:
 
-  $ echo '  $ echo foobar' >> anchor.t
-  $ echo '  foo (re)'      >> anchor.t
-  $ echo '  $ echo foobar' >> anchor.t
-  $ echo '  bar (re)'      >> anchor.t
+  $ cat > anchor.t << EOM
+  >   $ echo foobar
+  >   foo (re)
+  >   $ echo foobar
+  >   bar (re)
+  > EOM
   $ cram anchor.t
   F
   When executing "echo foobar":


### PR DESCRIPTION
We now support shell commands that span multiple lines (such as function definitions and here-documents). Simply start each continued line with a `>` marker. The lines will be copied directly to the shell script, with no banner commands in between.

Fixes #23.