### PR TITLE
main: ensure unique test directory for each test

### DIFF
--- a/cram.go
+++ b/cram.go
@@ -402,6 +402,8 @@ func Process(tempdir, path string, idx int) (result ExecutedTest, err error) {
 
 	// Create unique base inside the tempdir
 	base := fmt.Sprintf("%03d-%s", idx, filepath.Base(path))
+	// Remove file extension (often, but not necessarily ".t")
+	base = base[:len(base)-len(filepath.Ext(base))]
 	workdir := filepath.Join(tempdir, base)
 	err = os.Mkdir(workdir, 0700)
 	if err != nil {

--- a/cram.go
+++ b/cram.go
@@ -386,8 +386,10 @@ func Patch(r io.Reader, w io.Writer, cmds []ExecutedCommand) (err error) {
 }
 
 // Process parses a .t file, executes the test commands and compares
-// the actual output to the expected output.
-func Process(tempdir, path string) (result ExecutedTest, err error) {
+// the actual output to the expected output. The idx passed is used to
+// make the working directory unique inside tempdir and must be
+// different for each test file.
+func Process(tempdir, path string, idx int) (result ExecutedTest, err error) {
 	fp, err := os.Open(path)
 	if err != nil {
 		return
@@ -398,7 +400,9 @@ func Process(tempdir, path string) (result ExecutedTest, err error) {
 		return
 	}
 
-	workdir := filepath.Join(tempdir, filepath.Base(path))
+	// Create unique base inside the tempdir
+	base := fmt.Sprintf("%03d-%s", idx, filepath.Base(path))
+	workdir := filepath.Join(tempdir, base)
 	err = os.Mkdir(workdir, 0700)
 	if err != nil {
 		return

--- a/tests/basenames.t
+++ b/tests/basenames.t
@@ -1,8 +1,15 @@
 Test for issue #31 where Cram could not handle multiple test files
 with the same base name:
 
-  $ mkdir foo bar
+  $ mkdir tmp foo bar
   $ touch foo/empty.t bar/empty.t
-  $ cram foo/empty.t bar/empty.t
+  $ TMPDIR=tmp cram --keep-tmp foo/empty.t bar/empty.t
+  # Temporary directory: tmp/cram-* (glob)
   ..
   # Ran 2 tests (0 commands), 0 errors, 0 failures
+
+The tests are put into nicely numbered directories:
+
+  $ ls tmp/cram-*
+  000-empty
+  001-empty

--- a/tests/basenames.t
+++ b/tests/basenames.t
@@ -1,0 +1,8 @@
+Test for issue #31 where Cram could not handle multiple test files
+with the same base name:
+
+  $ mkdir foo bar
+  $ touch foo/empty.t bar/empty.t
+  $ cram foo/empty.t bar/empty.t
+  ..
+  # Ran 2 tests (0 commands), 0 errors, 0 failures

--- a/tests/tempdir.t
+++ b/tests/tempdir.t
@@ -13,7 +13,7 @@ This test will record the working directory in a file in our $PWD:
 The working directory recorded is indeed inside our $PWD:
 
   $ sed -e "s|^$PWD|<PWD>|" < pwd.txt
-  <PWD>/custom-tmp/cram-*/000-record-pwd.t (glob)
+  <PWD>/custom-tmp/cram-*/000-record-pwd (glob)
 
 The directory is normally deleted after the test has executed:
 

--- a/tests/tempdir.t
+++ b/tests/tempdir.t
@@ -13,7 +13,7 @@ This test will record the working directory in a file in our $PWD:
 The working directory recorded is indeed inside our $PWD:
 
   $ sed -e "s|^$PWD|<PWD>|" < pwd.txt
-  <PWD>/custom-tmp/cram-*/record-pwd.t (glob)
+  <PWD>/custom-tmp/cram-*/000-record-pwd.t (glob)
 
 The directory is normally deleted after the test has executed:
 


### PR DESCRIPTION
Before, we naively used the test file base name as the directory name.
This only worked when all tests had different base names.

We now add an unique integer (the index into the command line arguments)
to the test directory name. This avoids this kind of collisions.

Fixes #31.