### PR TITLE
Show current default for --jobs in help output

### DIFF
--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -134,10 +134,10 @@ func run(ctx *cli.Context) {
 	failures := []cram.ExecutedTest{}
 
 	// Number of goroutines to process the test files. We default to 2
-	// times the number of cores.
+	// times the number of cores in the main function below.
 	parallelism := ctx.GlobalInt("jobs")
-	if parallelism <= 0 {
-		parallelism = 2 * runtime.NumCPU()
+	if parallelism < 1 {
+		parallelism = 1
 	}
 	if parallelism > len(ctx.Args()) {
 		parallelism = len(ctx.Args())

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -207,6 +207,7 @@ func run(ctx *cli.Context) {
 
 func main() {
 	app := cli.NewApp()
+	app.Usage = "command line test framework"
 	app.Action = run
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -224,6 +224,7 @@ func main() {
 		cli.IntFlag{
 			Name:  "jobs, j",
 			Usage: "number of tests to run in parallel",
+			Value: 2 * runtime.NumCPU(),
 		},
 	}
 	app.Run(os.Args)

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -8,9 +8,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/codegangsta/cli"
 	"github.com/kylelemons/godebug/diff"
 	"github.com/mgeisler/cram"
+	"github.com/urfave/cli"
 )
 
 // We use a single, shared reader of os.Stdin to avoid losing data due

--- a/tests/help.t
+++ b/tests/help.t
@@ -2,7 +2,7 @@ Cram comes with builtin help:
 
   $ cram --help
   NAME:
-     cram - A new cli application
+     cram - command line test framework
   
   USAGE:
      cram [global options] command [command options] [arguments...]

--- a/tests/help.t
+++ b/tests/help.t
@@ -15,7 +15,7 @@ Cram comes with builtin help:
      --interactive           interactively update test file on failure
      --debug                 output debug information
      --keep-tmp              keep temporary directory after executing tests
-     --jobs value, -j value  number of tests to run in parallel (default: 0)
+     --jobs value, -j value  number of tests to run in parallel \(default: \d+\) (re)
      --help, -h              show help
      --version, -v           print the version
      


### PR DESCRIPTION
Instead of showing an internal default like `-1`, we now show the actual value that will be used (computed based on `runtime.NumCPU`).