### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Martin Geisler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -21,5 +21,10 @@ used in a production setting.
 Please take a look at [the Cram test suite][tests]. The tests there
 serve as documentation as well as a regression test suite.
 
+## License
+
+Cram is licensed under the [MIT license][license].
+
 [cram]: https://bitheap.org/cram/
 [tests]: tests/
+[license]: LICENSE

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Martin Geisler <martin@geisler.net>
+//
+// Cram is licensed under the MIT license, see the LICENSE file.
+
 package main
 
 import (

--- a/cram.go
+++ b/cram.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Martin Geisler <martin@geisler.net>
+//
+// Cram is licensed under the MIT license, see the LICENSE file.
+
 package cram
 
 import (

--- a/cram_test.go
+++ b/cram_test.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Martin Geisler <martin@geisler.net>
+//
+// Cram is licensed under the MIT license, see the LICENSE file.
+
 package cram
 
 import (

--- a/self_test.go
+++ b/self_test.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Martin Geisler <martin@geisler.net>
+//
+// Cram is licensed under the MIT license, see the LICENSE file.
+
 package cram
 
 import (

--- a/tests/fuzz/main.go
+++ b/tests/fuzz/main.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Martin Geisler <martin@geisler.net>
+//
+// Cram is licensed under the MIT license, see the LICENSE file.
+
 package ParseTest
 
 import (


### PR DESCRIPTION
While the original [Cram][1] is GPL licensed, this is a reimplementation from scratch and I prefer a more permissive license.

[1]: https://bitheap.org/cram/
