### PR TITLE
Add support for (no-eol) output lines

### DIFF
--- a/compat.go
+++ b/compat.go
@@ -1,0 +1,21 @@
+// Copyright 2016 Martin Geisler <martin@geisler.net>
+//
+// Cram is licensed under the MIT license, see the LICENSE file.
+
+package cram
+
+// Copies of standard library functions for compatibility with earlier
+// versions of Go.
+
+//// Go version 1.5 ////
+
+// LastIndexByte returns the index of the last instance of c in s, or
+// -1 if c is not present in s.
+func stringsLastIndexByte(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/cram_test.go
+++ b/cram_test.go
@@ -304,3 +304,23 @@ bar
 		assert.Equal(t, 1, executed[1].ActualExitCode)
 	}
 }
+
+func TestParseOutputNoEol(t *testing.T) {
+	cmds := []Command{
+		{"echo -n foo", nil, 0, 0},
+		{"echo -n bar", nil, 0, 0},
+	}
+	banner := "12345678-1234-abcd-1234-123412345678 ---"
+	output := []byte(`foo--- CRAM 0 12345678-1234-abcd-1234-123412345678 ---
+bar--- CRAM 1 12345678-1234-abcd-1234-123412345678 ---
+`)
+
+	executed, err := ParseOutput(cmds, output, banner)
+	assert.NoError(t, err)
+	if assert.Len(t, executed, 2) {
+		assert.Equal(t, []string{"foo"}, executed[0].ActualOutput)
+		assert.Equal(t, 0, executed[0].ActualExitCode)
+		assert.Equal(t, []string{"bar"}, executed[1].ActualOutput)
+		assert.Equal(t, 1, executed[1].ActualExitCode)
+	}
+}

--- a/cram_test.go
+++ b/cram_test.go
@@ -254,7 +254,7 @@ func TestMakeScript(t *testing.T) {
 		{"touch foo.txt", nil, 0, 0},
 	}
 	lines := MakeScript(cmds, MakeBanner(u))
-	banner := "echo \"--- CRAM 12345678-abcd-1234-abcd-123412345678 --- $?\"\n"
+	banner := "echo \"--- CRAM $? 12345678-abcd-1234-abcd-123412345678 ---\"\n"
 	if assert.Len(t, lines, 4) {
 		assert.Equal(t, "ls", lines[0])
 		assert.Equal(t, banner, lines[1])
@@ -268,9 +268,9 @@ func TestParseOutputEmpty(t *testing.T) {
 		{"touch foo", nil, 0, 0},
 		{"touch bar", nil, 0, 0},
 	}
-	banner := "--- CRAM 12345678-abcd-1234-abcd-123412345678 ---"
-	output := []byte(`--- CRAM 12345678-abcd-1234-abcd-123412345678 --- 0
---- CRAM 12345678-abcd-1234-abcd-123412345678 --- 1
+	banner := "12345678-abcd-1234-abcd-123412345678 ---"
+	output := []byte(`--- CRAM 0 12345678-abcd-1234-abcd-123412345678 ---
+--- CRAM 1 12345678-abcd-1234-abcd-123412345678 ---
 `)
 
 	executed, err := ParseOutput(cmds, output, banner)
@@ -288,11 +288,11 @@ func TestParseOutput(t *testing.T) {
 		{"echo foo", []string{"foo"}, 0, 0},
 		{"echo bar", []string{"bar"}, 0, 0},
 	}
-	banner := "--- CRAM 12345678-abcd-1234-abcd-123412345678 ---"
+	banner := "12345678-abcd-1234-abcd-123412345678 ---"
 	output := []byte(`foo
---- CRAM 12345678-abcd-1234-abcd-123412345678 --- 0
+--- CRAM 0 12345678-abcd-1234-abcd-123412345678 ---
 bar
---- CRAM 12345678-abcd-1234-abcd-123412345678 --- 1
+--- CRAM 1 12345678-abcd-1234-abcd-123412345678 ---
 `)
 
 	executed, err := ParseOutput(cmds, output, banner)

--- a/cram_test.go
+++ b/cram_test.go
@@ -318,9 +318,9 @@ bar--- CRAM 1 12345678-1234-abcd-1234-123412345678 ---
 	executed, err := ParseOutput(cmds, output, banner)
 	assert.NoError(t, err)
 	if assert.Len(t, executed, 2) {
-		assert.Equal(t, []string{"foo"}, executed[0].ActualOutput)
+		assert.Equal(t, []string{"foo (no-eol)\n"}, executed[0].ActualOutput)
 		assert.Equal(t, 0, executed[0].ActualExitCode)
-		assert.Equal(t, []string{"bar"}, executed[1].ActualOutput)
+		assert.Equal(t, []string{"bar (no-eol)\n"}, executed[1].ActualOutput)
 		assert.Equal(t, 1, executed[1].ActualExitCode)
 	}
 }

--- a/tests/no-eol.t
+++ b/tests/no-eol.t
@@ -1,0 +1,45 @@
+An output line with no final newline must be marked with (no-eol) for
+it to be considered a match:
+
+  $ echo -n hey
+  hey (no-eol)
+
+Changes in output are indicated using (no-eol) marker the diff output:
+
+  $ cat > diff.t << EOM
+  >   $ echo -n hello
+  >   hello
+  >   $ echo world
+  >   world (no-eol)
+  > EOM
+  $ cram diff.t
+  F
+  When executing "echo -n hello":
+  -hello
+  +hello (no-eol)
+  When executing "echo world":
+  -world (no-eol)
+  +world
+  # Ran 1 tests (2 commands), 0 errors, 1 failures
+  [1]
+
+When patching, the (no-eol) markers are inserted and removed as
+necessary:
+
+  $ yes | cram --interactive diff.t
+  F
+  When executing "echo -n hello":
+  -hello
+  +hello (no-eol)
+  Accept this change? When executing "echo world":
+  -world (no-eol)
+  +world
+  Accept this change? Patched diff.t
+  # Ran 1 tests (2 commands), 0 errors, 1 failures
+  [1]
+
+  $ cat diff.t
+    $ echo -n hello
+    hello (no-eol)
+    $ echo world
+    world


### PR DESCRIPTION
We can now parse `(no-eol)` output lines such as these:

    $ echo -n "hello"
    hello (no-eol)

Fixes #29.