### PR TITLE
Update command line parsing library

### DIFF
--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -135,7 +135,7 @@ func run(ctx *cli.Context) error {
 		defer os.RemoveAll(tempdir)
 	}
 
-	errors, cmdCount := 0, 0
+	errCount, cmdCount := 0, 0
 	failures := []cram.ExecutedTest{}
 
 	// Number of goroutines to process the test files. We default to 2
@@ -186,7 +186,7 @@ func run(ctx *cli.Context) error {
 		case err != nil:
 			fmt.Fprintln(os.Stderr, err)
 			fmt.Print("E")
-			errors++
+			errCount++
 		case len(test.Failures) > 0:
 			fmt.Print("F")
 			failures = append(failures, test)
@@ -199,10 +199,10 @@ func run(ctx *cli.Context) error {
 	processFailures(failures, ctx.GlobalBool("interactive"))
 
 	msg := fmt.Sprintf("# Ran %d tests (%d commands), %d errors, %d failures",
-		len(ctx.Args()), cmdCount, errors, len(failures))
+		len(ctx.Args()), cmdCount, errCount, len(failures))
 
 	exitCode := 0
-	if errors > 0 {
+	if errCount > 0 {
 		exitCode = 2
 	} else if len(failures) > 0 {
 		exitCode = 1

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -214,6 +214,7 @@ func run(paths []string, parallelism int,
 func main() {
 	interactive := kingpin.
 		Flag("interactive", "interactively update test file on failure").
+		Short('i').
 		Bool()
 	debug := kingpin.
 		Flag("debug", "output debug information").

--- a/tests/cmdline.t
+++ b/tests/cmdline.t
@@ -1,0 +1,13 @@
+Cram uses a traditional flexible GNU-style command line parser. This
+means that you can specify flags anywhere on the command line:
+
+  $ touch foo.t bar.t
+  $ cram foo.t -j 3 bar.t
+  ..
+  # Ran 2 tests (0 commands), 0 errors, 0 failures
+
+You can also use short options without a space:
+
+  $ cram -ij 2 foo.t
+  .
+  # Ran 1 tests (0 commands), 0 errors, 0 failures

--- a/tests/help.t
+++ b/tests/help.t
@@ -6,7 +6,7 @@ Cram comes with builtin help:
   Flags:
         --help         Show context-sensitive help (also try --help-long and
                        --help-man).
-        --interactive  interactively update test file on failure
+    -i, --interactive  interactively update test file on failure
         --debug        output debug information
         --keep-tmp     keep temporary directory after executing tests
     -j, --jobs=\d+ +   number of tests to run in parallel (re)

--- a/tests/help.t
+++ b/tests/help.t
@@ -11,6 +11,8 @@ Cram comes with builtin help:
      0.0.0
      
   COMMANDS:
+       help, h  Shows a list of commands or help for one command
+  
   GLOBAL OPTIONS:
      --interactive           interactively update test file on failure
      --debug                 output debug information

--- a/tests/help.t
+++ b/tests/help.t
@@ -1,26 +1,22 @@
 Cram comes with builtin help:
 
   $ cram --help
-  NAME:
-     cram - command line test framework
+  usage: cram [<flags>] <path>...
   
-  USAGE:
-     cram [global options] command [command options] [arguments...]
-     
-  VERSION:
-     0.0.0
-     
-  COMMANDS:
-       help, h  Shows a list of commands or help for one command
+  Flags:
+        --help         Show context-sensitive help (also try --help-long and
+                       --help-man).
+        --interactive  interactively update test file on failure
+        --debug        output debug information
+        --keep-tmp     keep temporary directory after executing tests
+    -j, --jobs=\d+ +   number of tests to run in parallel (re)
+        --version      Show application version.
   
-  GLOBAL OPTIONS:
-     --interactive           interactively update test file on failure
-     --debug                 output debug information
-     --keep-tmp              keep temporary directory after executing tests
-     --jobs value, -j value  number of tests to run in parallel \(default: \d+\) (re)
-     --help, -h              show help
-     --version, -v           print the version
-     
+  Args:
+    <path>  test files
+  
+  [1]
+
 The traditional --version flag also works:
 
   $ cram --version


### PR DESCRIPTION
This switches the command line parsing library from github/urfave/cli to github.com/alecthomas/kingpin. That library seems to follow the traditional GNU style more closely.

The `--interactive` flag now also be specified as `-i`.