### PR TITLE
Add --verbose flag

### DIFF
--- a/cram.go
+++ b/cram.go
@@ -476,6 +476,8 @@ func Patch(r io.Reader, w io.Writer, cmds []ExecutedCommand) (err error) {
 // make the working directory unique inside tempdir and must be
 // different for each test file.
 func Process(tempdir, path string, idx int) (result ExecutedTest, err error) {
+	// Make sure Path is set, even if we fail later.
+	result.Path = path
 	fp, err := os.Open(path)
 	if err != nil {
 		return

--- a/cram_test.go
+++ b/cram_test.go
@@ -376,3 +376,9 @@ bar--- CRAM 1 12345678-1234-abcd-1234-123412345678 ---
 		assert.Equal(t, 1, executed[1].ActualExitCode)
 	}
 }
+
+func TestProcessInvalidPath(t *testing.T) {
+	test, err := Process("/tmp", "no-such-file.t", 0)
+	assert.Equal(t, test.Path, "no-such-file.t")
+	assert.Error(t, err)
+}

--- a/cram_test.go
+++ b/cram_test.go
@@ -189,6 +189,7 @@ func TestParseOutputOnly(t *testing.T) {
 	test, err := ParseTest(buf, "<string>")
 
 	assert.EqualError(t, err, `<string>:2: Output line "  \n" has no command`)
+	assert.Equal(t, test.Path, "<string>")
 	assert.Len(t, test.Cmds, 0)
 }
 

--- a/tests/help.t
+++ b/tests/help.t
@@ -7,6 +7,7 @@ Cram comes with builtin help:
         --help         Show context-sensitive help (also try --help-long and
                        --help-man).
     -i, --interactive  interactively update test file on failure
+    -v, --verbose      show names of test files
         --debug        output debug information
         --keep-tmp     keep temporary directory after executing tests
     -j, --jobs=\d+ +   number of tests to run in parallel (re)

--- a/tests/verbose.t
+++ b/tests/verbose.t
@@ -1,0 +1,33 @@
+The -v or --verbose flag can be used to make Cram output the names of
+the test files as they execute. The order depends on the scheduling of
+the goroutines, so we add -j 1 here to make the order consistent:
+
+  $ touch foo.t bar.t
+  $ cram -v -j 1 foo.t bar.t
+  . foo.t: 0 commands passed
+  . bar.t: 0 commands passed
+  
+  # Ran 2 tests (0 commands), 0 errors, 0 failures
+
+The number of failed commands is shown for failed test files:
+
+  $ cat > failure.t << EOM
+  >   $ false
+  >   $ true
+  > EOM
+  $ cram -v failure.t
+  F failure.t: 1 of 2 commands failed
+  
+  When executing "false":
+  +[1]
+  # Ran 1 tests (2 commands), 0 errors, 1 failures
+  [1]
+
+Tests with errors have the errors shown:
+
+  $ echo "  > bad" > error.t
+  $ cram -v error.t
+  E error.t:0: Continuation line "  > bad\n" has no command
+  
+  # Ran 1 tests (0 commands), 1 errors, 0 failures
+  [2]


### PR DESCRIPTION
This flag shows the test file names as they are executed. Unlike a lot
of other test runners, we show the test status as the first character to
keep a nice column alignment:

    . passed.t: 3 commands passed
    F failure.t: 2/5 commands failed
    E error.t:10: an error happened here
