### PR TITLE
Support directory recursion

### DIFF
--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -306,7 +306,7 @@ func main() {
 		Int()
 	paths := kingpin.
 		Arg("path", "test files or directories").
-		Required().
+		Default(".").
 		Strings()
 
 	kingpin.Version("cram version 0.0.0")

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -148,7 +148,7 @@ func run(paths []string, opts Options) (error, int) {
 		defer os.RemoveAll(tempdir)
 	}
 
-	errCount, cmdCount := 0, 0
+	errCount, cmdCount, resultCount := 0, 0, 0
 	failures := []cram.ExecutedTest{}
 
 	// Number of goroutines to process the test files. We default to 2
@@ -193,6 +193,7 @@ func run(paths []string, opts Options) (error, int) {
 	}()
 
 	for result := range results {
+		resultCount++
 		test := result.Test
 		err := result.Err
 
@@ -239,7 +240,7 @@ func run(paths []string, opts Options) (error, int) {
 	processFailures(failures, opts.Interactive)
 
 	msg := fmt.Sprintf("# Ran %d tests (%d commands), %d errors, %d failures",
-		len(paths), cmdCount, errCount, len(failures))
+		resultCount, cmdCount, errCount, len(failures))
 
 	exitCode := 0
 	if errCount > 0 {

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -128,7 +128,7 @@ type processResult struct {
 // Options describe the command line options. They are parsed in main
 // and passed to run.
 type Options struct {
-	Parallelism int
+	Jobs        int
 	KeepTmp     bool
 	Interactive bool
 	Verbose     bool
@@ -152,11 +152,11 @@ func run(paths []string, opts Options) (error, int) {
 
 	// Number of goroutines to process the test files. We default to 2
 	// times the number of cores in the main function below.
-	if opts.Parallelism < 1 {
-		opts.Parallelism = 1
+	if opts.Jobs < 1 {
+		opts.Jobs = 1
 	}
-	if opts.Parallelism > len(paths) {
-		opts.Parallelism = len(paths)
+	if opts.Jobs > len(paths) {
+		opts.Jobs = len(paths)
 	}
 
 	// Input and result channels with space for a few items before we
@@ -164,7 +164,7 @@ func run(paths []string, opts Options) (error, int) {
 	indexes := make(chan int, 8)
 	results := make(chan processResult, 8)
 
-	for i := 0; i < opts.Parallelism; i++ {
+	for i := 0; i < opts.Jobs; i++ {
 		go func() {
 			for i := range indexes {
 				result, err := cram.Process(tempdir, paths[i], i)

--- a/cmd/cram/main.go
+++ b/cmd/cram/main.go
@@ -225,11 +225,8 @@ func run(args []string, opts Options) (error, int) {
 	var jobs sync.WaitGroup
 	jobs.Add(opts.Jobs)
 
-	// Close the results channel when done.
-	go func() {
-		jobs.Wait()
-		close(results)
-	}()
+	// Expand the command line arguments into pathIndex elements.
+	go expandArgs(args, paths)
 
 	// Start the worker goroutines that will process the test files
 	// found by expandArgs.
@@ -237,8 +234,11 @@ func run(args []string, opts Options) (error, int) {
 		go processPath(&jobs, tempdir, paths, results)
 	}
 
-	// Expand the command line arguments into pathIndex elements.
-	go expandArgs(args, paths)
+	// Close the results channel when done.
+	go func() {
+		jobs.Wait()
+		close(results)
+	}()
 
 	for result := range results {
 		resultCount++

--- a/self_test.go
+++ b/self_test.go
@@ -6,18 +6,12 @@ package cram
 
 import (
 	"os/exec"
-	"path/filepath"
 	"testing"
 )
 
 // TestSelf runs Cram on all .t files inside the tests directory.
 func TestSelf(t *testing.T) {
-	paths, err := filepath.Glob("tests/*.t")
-	if err != nil {
-		t.Fatal("Error while globbing:", err)
-	}
-
-	cmd := exec.Command("cram", paths...)
+	cmd := exec.Command("cram", "tests")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Log("Cram failed:", err)

--- a/tests/help.t
+++ b/tests/help.t
@@ -14,7 +14,7 @@ Cram comes with builtin help:
         --version      Show application version.
   
   Args:
-    <path>  test files
+    <path>  test files or directories
   
   [1]
 

--- a/tests/help.t
+++ b/tests/help.t
@@ -1,7 +1,7 @@
 Cram comes with builtin help:
 
   $ cram --help
-  usage: cram [<flags>] <path>...
+  usage: cram [<flags>] [<path>...]
   
   Flags:
         --help         Show context-sensitive help (also try --help-long and
@@ -14,7 +14,7 @@ Cram comes with builtin help:
         --version      Show application version.
   
   Args:
-    <path>  test files or directories
+    [<path>]  test files or directories
   
   [1]
 

--- a/tests/recursion.t
+++ b/tests/recursion.t
@@ -9,6 +9,13 @@ Cram can recursively find test files inside a directory:
   
   # Ran 3 tests (0 commands), 0 errors, 0 failures
 
+Starting Cram without any arguments will make it recurse from the
+current directory:
+
+  $ cram
+  ...
+  # Ran 3 tests (0 commands), 0 errors, 0 failures
+
 It is only .t files that are found:
 
   $ touch foo/bar.go

--- a/tests/recursion.t
+++ b/tests/recursion.t
@@ -1,0 +1,29 @@
+Cram can recursively find test files inside a directory:
+
+  $ mkdir -p foo/x foo/y
+  $ touch foo/a.t foo/x/b.t foo/y/c.t
+  $ cram -v -j 1 foo
+  . foo/a.t: 0 commands passed
+  . foo/x/b.t: 0 commands passed
+  . foo/y/c.t: 0 commands passed
+  
+  # Ran 3 tests (0 commands), 0 errors, 0 failures
+
+It is only .t files that are found:
+
+  $ touch foo/bar.go
+  $ cram -v -j 1 foo
+  . foo/a.t: 0 commands passed
+  . foo/x/b.t: 0 commands passed
+  . foo/y/c.t: 0 commands passed
+  
+  # Ran 3 tests (0 commands), 0 errors, 0 failures
+
+Explicit paths on the command line can have any extension:
+
+  $ touch README.md tests.txt
+  $ cram -v -j 1 README.md tests.txt
+  . README.md: 0 commands passed
+  . tests.txt: 0 commands passed
+  
+  # Ran 2 tests (0 commands), 0 errors, 0 failures


### PR DESCRIPTION
Cram can now recurse into directories mentioned on the command line. Running

    $ cram

will now find test files under the current directory.

Fixes #32.
