### PR TITLE
Environment variables

### DIFF
--- a/cram.go
+++ b/cram.go
@@ -333,6 +333,9 @@ func MakeEnvironment(path string) ([]string, error) {
 	env["LANGUAGE"] = "C"
 	// Reset timezone
 	env["TZ"] = "GMT"
+	// Remove potentially problematic variables
+	delete(env, "CDPATH")
+	delete(env, "GREP_OPTIONS")
 	return unparseEnviron(env), nil
 }
 

--- a/cram.go
+++ b/cram.go
@@ -333,6 +333,9 @@ func MakeEnvironment(path string) ([]string, error) {
 	env["LANGUAGE"] = "C"
 	// Reset timezone
 	env["TZ"] = "GMT"
+	// Reset terminal
+	env["TERM"] = "xterm"
+	env["COLUMNS"] = "80"
 	// Remove potentially problematic variables
 	delete(env, "CDPATH")
 	delete(env, "GREP_OPTIONS")

--- a/cram.go
+++ b/cram.go
@@ -331,6 +331,8 @@ func MakeEnvironment(path string) ([]string, error) {
 	env["LC_ALL"] = "C"
 	env["LANG"] = "C"
 	env["LANGUAGE"] = "C"
+	// Reset timezone
+	env["TZ"] = "GMT"
 	return unparseEnviron(env), nil
 }
 

--- a/cram.go
+++ b/cram.go
@@ -327,6 +327,10 @@ func MakeEnvironment(path string) ([]string, error) {
 	env := parseEnviron(os.Environ())
 	// Test file directory
 	env["TESTDIR"] = filepath.Dir(abs)
+	// Reset locale variables
+	env["LC_ALL"] = "C"
+	env["LANG"] = "C"
+	env["LANGUAGE"] = "C"
 	return unparseEnviron(env), nil
 }
 

--- a/cram.go
+++ b/cram.go
@@ -30,6 +30,8 @@ const (
 	escSuffix   = " (esc)"
 )
 
+type Env map[string]string
+
 type InvalidTestError struct {
 	Path   string // Path to test file.
 	Lineno int    // Line number of failure
@@ -288,6 +290,46 @@ func MakeScript(cmds []Command, banner string) (lines []string) {
 	return
 }
 
+// parseEnviron turns a slice of "key=value" pairs into a map from
+// "key" to "value". The inverse is unparseEnviron.
+func parseEnviron(pairs []string) Env {
+	env := make(Env, len(pairs))
+	for _, pair := range pairs {
+		i := strings.IndexByte(pair, '=')
+		if i < 0 {
+			panic(fmt.Sprintf("parseEnviron: found no '=' in %q", pair))
+		}
+		env[pair[:i]] = pair[i+1:]
+	}
+	return env
+}
+
+// unparseEnviron turns a map of keys and values into a slice of
+// "key=value" strings. It is the inverse of parseEnviron.
+func unparseEnviron(env Env) []string {
+	pairs := make([]string, len(env))
+	i := 0
+	for key, value := range env {
+		pairs[i] = key + "=" + value
+		i++
+	}
+	return pairs
+}
+
+// MakeEnvironment prepares the environment to be used when executing
+// the test in the given path. It currently sets TESTDIR to the
+// dirname of path.
+func MakeEnvironment(path string) ([]string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	env := parseEnviron(os.Environ())
+	// Test file directory
+	env["TESTDIR"] = filepath.Dir(abs)
+	return unparseEnviron(env), nil
+}
+
 // Escape quotes non-printable characters in s with a backslash. If
 // anything was changed, " (esc)" is added to the result. A final
 // newline in s (if any) is kept unescaped.
@@ -390,10 +432,11 @@ func ParseOutput(cmds []Command, output []byte, banner string) (
 }
 
 // Execute a script in the specified working directory.
-func ExecuteScript(workdir string, lines []string) ([]byte, error) {
+func ExecuteScript(workdir string, env []string, lines []string) ([]byte, error) {
 	script := strings.Join(lines, "")
 	cmd := exec.Command("/bin/sh", "-")
 	cmd.Dir = workdir
+	cmd.Env = env
 	cmd.Stdin = strings.NewReader(script)
 	return cmd.CombinedOutput()
 }
@@ -501,8 +544,12 @@ func Process(tempdir, path string, idx int) (result ExecutedTest, err error) {
 	u := uuid.NewV4()
 	banner := MakeBanner(u)
 	lines := MakeScript(test.Cmds, banner)
+	env, err := MakeEnvironment(path)
+	if err != nil {
+		return
+	}
 
-	output, err := ExecuteScript(workdir, lines)
+	output, err := ExecuteScript(workdir, env, lines)
 	if err != nil {
 		return
 	}

--- a/cram_test.go
+++ b/cram_test.go
@@ -363,6 +363,9 @@ func TestMakeEnvironment(t *testing.T) {
 	assert.NoError(t, err)
 	env := parseEnviron(pairs)
 	assert.Equal(t, "/foo", env["TESTDIR"])
+	assert.Equal(t, "C", env["LANG"])
+	assert.Equal(t, "C", env["LC_ALL"])
+	assert.Equal(t, "C", env["LANGUAGE"])
 }
 
 func TestParseOutputEmpty(t *testing.T) {

--- a/cram_test.go
+++ b/cram_test.go
@@ -366,6 +366,7 @@ func TestMakeEnvironment(t *testing.T) {
 	assert.Equal(t, "C", env["LANG"])
 	assert.Equal(t, "C", env["LC_ALL"])
 	assert.Equal(t, "C", env["LANGUAGE"])
+	assert.Equal(t, "GMT", env["TZ"])
 }
 
 func TestParseOutputEmpty(t *testing.T) {

--- a/cram_test.go
+++ b/cram_test.go
@@ -315,6 +315,13 @@ func TestMakeScript(t *testing.T) {
 	}
 }
 
+func TestMakeEnvironment(t *testing.T) {
+	pairs, err := MakeEnvironment("/foo/bar.t")
+	assert.NoError(t, err)
+	env := parseEnviron(pairs)
+	assert.Equal(t, "/foo", env["TESTDIR"])
+}
+
 func TestParseOutputEmpty(t *testing.T) {
 	cmds := []Command{
 		{"touch foo", nil, 0, 0},

--- a/cram_test.go
+++ b/cram_test.go
@@ -367,6 +367,8 @@ func TestMakeEnvironment(t *testing.T) {
 	assert.Equal(t, "C", env["LC_ALL"])
 	assert.Equal(t, "C", env["LANGUAGE"])
 	assert.Equal(t, "GMT", env["TZ"])
+	assert.Equal(t, "xterm", env["TERM"])
+	assert.Equal(t, "80", env["COLUMNS"])
 }
 
 func TestParseOutputEmpty(t *testing.T) {

--- a/cram_test.go
+++ b/cram_test.go
@@ -6,6 +6,7 @@ package cram
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
@@ -312,6 +313,48 @@ func TestMakeScript(t *testing.T) {
 		assert.Equal(t, banner, lines[1])
 		assert.Equal(t, "touch foo.txt", lines[2])
 		assert.Equal(t, banner, lines[3])
+	}
+}
+
+func TestParseEnviron(t *testing.T) {
+	var tests = []struct {
+		input    []string
+		expected Env
+	}{
+		{[]string{}, Env{}},
+		{[]string{"foo="}, Env{"foo": ""}},
+		{[]string{"foo=x", "bar=y"}, Env{"foo": "x", "bar": "y"}},
+		{[]string{"foo=x", "foo=y"}, Env{"foo": "y"}},
+	}
+
+	for _, test := range tests {
+		actual := parseEnviron(test.input)
+		assert.Equal(t, test.expected, actual,
+			fmt.Sprintf("parseEnviron(%#v)", test.input))
+	}
+}
+
+func TestParseEnvironError(t *testing.T) {
+	assert.Panics(t, func() {
+		parseEnviron([]string{"malformed entry"})
+	})
+}
+
+func TestUnparseEnviron(t *testing.T) {
+	var tests = []struct {
+		input    Env
+		expected []string
+	}{
+		{Env{}, []string{}},
+		{Env{"foo": "x", "bar": "y"}, []string{"bar=y", "foo=x"}},
+		{Env{"foo": ""}, []string{"foo="}},
+	}
+
+	for _, test := range tests {
+		actual := unparseEnviron(test.input)
+		sort.Strings(actual)
+		assert.Equal(t, test.expected, actual,
+			fmt.Sprintf("unparseEnviron(%#v)", test.input))
 	}
 }
 

--- a/tests/envvars.t
+++ b/tests/envvars.t
@@ -1,0 +1,23 @@
+When Cram executes a test file, $TESTDIR will point to the directory
+where the test file was.
+
+  $ cat > x.t << EOM
+  >   $ echo \$TESTDIR
+  >   $PWD
+  > EOM
+  $ cram
+  .
+  # Ran 1 tests (1 commands), 0 errors, 0 failures
+
+This can differ from one test file to another:
+
+  $ mkdir -p foo
+  $ cat > foo/y.t << EOM
+  >   $ echo \$TESTDIR
+  >   $PWD/foo
+  > EOM
+
+  $ cd foo
+  $ cram -j 1 ../
+  ..
+  # Ran 2 tests (2 commands), 0 errors, 0 failures

--- a/tests/envvars.t
+++ b/tests/envvars.t
@@ -21,3 +21,8 @@ This can differ from one test file to another:
   $ cram -j 1 ../
   ..
   # Ran 2 tests (2 commands), 0 errors, 0 failures
+
+Environment variables related to the locale are also reset:
+
+  $ echo $LC_ALL, $LANG, $LANGUAGE
+  C, C, C

--- a/tests/envvars.t
+++ b/tests/envvars.t
@@ -31,3 +31,16 @@ The timezone is reset to GMT:
 
   $ echo $TZ
   GMT
+
+The CDPATH and GREP_OPTIONS environment variables are removed from the
+environment:
+
+  $ cat > reset.t << EOM
+  >   $ echo \$CDPATH
+  >   
+  >   $ echo \$GREP_OPTIONS
+  >   
+  > EOM
+  $ CDPATH=foo GREP_OPTIONS=bar cram reset.t
+  .
+  # Ran 1 tests (2 commands), 0 errors, 0 failures

--- a/tests/envvars.t
+++ b/tests/envvars.t
@@ -26,3 +26,8 @@ Environment variables related to the locale are also reset:
 
   $ echo $LC_ALL, $LANG, $LANGUAGE
   C, C, C
+
+The timezone is reset to GMT:
+
+  $ echo $TZ
+  GMT

--- a/tests/envvars.t
+++ b/tests/envvars.t
@@ -32,6 +32,11 @@ The timezone is reset to GMT:
   $ echo $TZ
   GMT
 
+The terminal is always an xterm with 80 columns:
+
+  $ echo $TERM $COLUMNS
+  xterm 80
+
 The CDPATH and GREP_OPTIONS environment variables are removed from the
 environment:
 


### PR DESCRIPTION
This pull requests makes Cram set `$TESTDIR` to the directory where the test lives. This is very useful for sourcing common test setup files from the test directory.

Cram now also resets a number of environment variables that could affect test output.

Fixes #21.