### PR TITLE
tests/help: cram --help now has exit code 0

### DIFF
--- a/tests/help.t
+++ b/tests/help.t
@@ -16,7 +16,6 @@ Cram comes with builtin help:
   Args:
     [<path>]  test files or directories
   
-  [1]
 
 The traditional --version flag also works:
 


### PR DESCRIPTION
After alecthomas/kingpin#136, "cram --help" has an exit code of 0.

This should fix the unstable build on Shippable.
